### PR TITLE
feat: add encyclopedia deep-dive pages and fix dark/light theme CSS v…

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,6 @@
 <div id="container">
   <app-sidebar></app-sidebar>
   <div id="content">
-    <div [@fadeIn] class="page-container">
-      <router-outlet></router-outlet>
-    </div>
+    <router-outlet></router-outlet>
   </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './sidebar/sidebar.component';
-import { trigger, transition, style, animate } from '@angular/animations';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -13,20 +13,16 @@ import { trigger, transition, style, animate } from '@angular/animations';
     SidebarComponent
   ],
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
-  animations: [
-    trigger('fadeIn', [
-      transition(':enter', [
-        style({ opacity: 0, transform: 'translateY(8px)' }),
-        animate('200ms ease-out', style({ opacity: 1, transform: 'translateY(0)' }))
-      ]),
-      transition(':leave', [
-        animate('150ms ease-in', style({ opacity: 0, transform: 'translateY(-8px)' }))
-      ])
-    ])
-  ]
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'Pokédex';
-}
 
+  constructor(private router: Router) {
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd)
+    ).subscribe(() => {
+      window.scrollTo(0, 0);
+    });
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,6 +52,31 @@ export const routes: Routes = [
       .then(m => m.AbilityDetailComponent)
   },
   {
+    path: 'evolution-chains',
+    loadComponent: () => import('./evolution-chains/evolution-chains.component')
+      .then(m => m.EvolutionChainsComponent)
+  },
+  {
+    path: 'battle-strategy',
+    loadComponent: () => import('./battle-strategy/battle-strategy.component')
+      .then(m => m.BattleStrategyComponent)
+  },
+  {
+    path: 'locations',
+    loadComponent: () => import('./locations/locations.component')
+      .then(m => m.LocationsComponent)
+  },
+  {
+    path: 'types',
+    loadComponent: () => import('./types-deep-dive/types-deep-dive.component')
+      .then(m => m.TypesDeepDiveComponent)
+  },
+  {
+    path: 'natures',
+    loadComponent: () => import('./natures-stats/natures-stats.component')
+      .then(m => m.NaturesStatsComponent)
+  },
+  {
     path: '**',
     redirectTo: ''
   }

--- a/src/app/battle-strategy/battle-strategy.component.html
+++ b/src/app/battle-strategy/battle-strategy.component.html
@@ -1,0 +1,245 @@
+<div class="battle-strategy-container">
+  <ds-page-header title="Battle Strategy" subtitle="Type matchups and damage calculator"></ds-page-header>
+
+  @if (loading()) {
+    <div class="loading-container">
+      <ds-pokeball-spinner [size]="60" label="Loading type data..."></ds-pokeball-spinner>
+    </div>
+  } @else {
+    <div class="tab-switcher">
+      <button
+        mat-button
+        [class.active]="activeTab() === 'chart'"
+        (click)="setActiveTab('chart')"
+      >
+        <mat-icon>grid_on</mat-icon>
+        Type Chart
+      </button>
+      <button
+        mat-button
+        [class.active]="activeTab() === 'calculator'"
+        (click)="setActiveTab('calculator')"
+      >
+        <mat-icon>calculate</mat-icon>
+        Damage Calculator
+      </button>
+    </div>
+
+    @if (activeTab() === 'chart') {
+      <div class="type-chart-section">
+        <div class="chart-controls">
+          <div class="search-box">
+            <mat-icon>search</mat-icon>
+            <input type="text" placeholder="Filter types..." [(ngModel)]="typeSearch" />
+          </div>
+          <div class="view-toggle">
+            <button mat-button [class.active]="!selectedDefensiveTypes().length" (click)="clearDefensiveSelection()">
+              <mat-icon>grid_on</mat-icon>
+              Offensive Chart
+            </button>
+            <button mat-button [class.active]="selectedDefensiveTypes().length > 0" (click)="toggleDefensiveType('fire')">
+              <mat-icon>shield</mat-icon>
+              Defensive View
+            </button>
+          </div>
+        </div>
+
+        <div class="type-chart-wrapper">
+          <div class="type-chart-grid">
+            <div class="corner-cell"></div>
+            @for (defType of filteredTypes(); track defType) {
+              <div class="header-cell defending-header">
+                <ds-type-badge [type]="defType" size="sm" variant="solid"></ds-type-badge>
+              </div>
+            }
+
+            @for (atkType of filteredTypes(); track atkType) {
+              <div class="header-cell attacking-header">
+                <ds-type-badge [type]="atkType" size="sm" variant="solid"></ds-type-badge>
+              </div>
+              @for (defType of filteredTypes(); track defType) {
+                @let effectiveness = getEffectiveness(atkType, defType);
+                <div
+                  class="effectiveness-cell {{ getCellClass(effectiveness) }}"
+                  [class.highlighted]="isTypeSelected(atkType) || isTypeSelected(defType)"
+                  [class.row-selected]="isTypeSelected(atkType)"
+                  [class.column-selected]="isTypeSelected(defType)"
+                  (click)="selectType(atkType)"
+                  (mouseenter)="onCellHover(atkType, defType)"
+                  (mouseleave)="onCellLeave()"
+                >
+                  {{ getEffectivenessLabel(effectiveness) }}
+                </div>
+              }
+            }
+          </div>
+        </div>
+
+        @if (hoveredCell()) {
+          <div class="hover-tooltip">
+            <ds-type-badge [type]="hoveredCell()!.attackingType" size="sm" variant="solid"></ds-type-badge>
+            <span class="tooltip-arrow">vs</span>
+            <ds-type-badge [type]="hoveredCell()!.defendingType" size="sm" variant="solid"></ds-type-badge>
+            <span class="tooltip-result" [class]="getCellClass(hoveredCell()!.effectiveness)">
+              {{ hoveredCell()!.label }} ({{ getEffectivenessLabel(hoveredCell()!.effectiveness) }})
+            </span>
+          </div>
+        }
+
+        @if (selectedType()) {
+          <div class="type-info-panel">
+            <h3>{{ selectedType() | titlecase }} Type Matchups</h3>
+            <div class="matchup-groups">
+              <div class="matchup-group">
+                <h4><mat-icon>arrow_upward</mat-icon> Strong Against (2x)</h4>
+                <div class="type-badges">
+                  @for (type of moveRecommendations().strongAgainst; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>arrow_downward</mat-icon> Weak Against (0.5x / 0x)</h4>
+                <div class="type-badges">
+                  @for (type of moveRecommendations().weakAgainst; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>dangerous</mat-icon> Weak To (takes 2x)</h4>
+                <div class="type-badges">
+                  @for (type of moveRecommendations().weakTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>shield</mat-icon> Resistant To (takes 0.5x / 0x)</h4>
+                <div class="type-badges">
+                  @for (type of moveRecommendations().resistantTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+
+        @if (selectedDefensiveTypes().length > 0) {
+          <div class="type-info-panel defensive-panel">
+            <div class="defensive-header">
+              <h3>Defensive Matchups</h3>
+              <div class="selected-types">
+                @for (type of selectedDefensiveTypes(); track type) {
+                  <ds-type-badge [type]="type" size="sm" variant="solid"></ds-type-badge>
+                }
+              </div>
+            </div>
+            <div class="matchup-groups">
+              <div class="matchup-group">
+                <h4><mat-icon>dangerous</mat-icon> Weak To ({{ defensiveMatchups().weakTo.length }})</h4>
+                <div class="type-badges">
+                  @for (type of defensiveMatchups().weakTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  } @empty {
+                    <span class="empty-msg">None</span>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>shield</mat-icon> Resistant To ({{ defensiveMatchups().resistantTo.length }})</h4>
+                <div class="type-badges">
+                  @for (type of defensiveMatchups().resistantTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  } @empty {
+                    <span class="empty-msg">None</span>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>block</mat-icon> Immune To ({{ defensiveMatchups().immuneTo.length }})</h4>
+                <div class="type-badges">
+                  @for (type of defensiveMatchups().immuneTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="outline"></ds-type-badge>
+                  } @empty {
+                    <span class="empty-msg">None</span>
+                  }
+                </div>
+              </div>
+              <div class="matchup-group">
+                <h4><mat-icon>swap_horiz</mat-icon> Neutral To ({{ defensiveMatchups().neutralTo.length }})</h4>
+                <div class="type-badges">
+                  @for (type of defensiveMatchups().neutralTo; track type) {
+                    <ds-type-badge [type]="type" size="sm" variant="ghost"></ds-type-badge>
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    }
+
+    @if (activeTab() === 'calculator') {
+      <div class="calculator-section">
+        <form [formGroup]="calculatorForm" class="calculator-form">
+          <mat-form-field appearance="outline">
+            <mat-label>Attacking Type</mat-label>
+            <mat-select formControlName="attackingType">
+              @for (type of types; track type) {
+                <mat-option [value]="type">
+                  <ds-type-badge [type]="type" size="sm" variant="solid"></ds-type-badge>
+                </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Defending Type(s)</mat-label>
+            <mat-select formControlName="defendingTypes" multiple>
+              @for (type of types; track type) {
+                <mat-option [value]="type">
+                  <ds-type-badge [type]="type" size="sm" variant="solid"></ds-type-badge>
+                </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Power</mat-label>
+            <input matInput type="number" formControlName="power" min="0" max="255">
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Level</mat-label>
+            <input matInput type="number" formControlName="level" min="1" max="100">
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" (click)="calculateDamage()" type="button">
+            <mat-icon>calculate</mat-icon>
+            Calculate Damage
+          </button>
+        </form>
+
+        @if (damageResult()) {
+          <div class="damage-result">
+            <div class="result-header">
+              <h3>Damage Result</h3>
+              <span class="effectiveness-badge" [class]="damageResult()!.effectiveness > 1 ? 'super-effective' : damageResult()!.effectiveness < 1 ? 'not-effective' : 'neutral'">
+                {{ damageResult()!.label }}
+              </span>
+            </div>
+            <div class="result-value">
+              <span class="damage-number">{{ damageResult()!.damage }}</span>
+              <span class="damage-label">damage</span>
+            </div>
+            <div class="result-details">
+              <p>Effectiveness: {{ damageResult()!.effectiveness }}x</p>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  }
+</div>

--- a/src/app/battle-strategy/battle-strategy.component.scss
+++ b/src/app/battle-strategy/battle-strategy.component.scss
@@ -1,0 +1,589 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.battle-strategy-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.tab-switcher {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 32px;
+  justify-content: center;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 24px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-subtle);
+    transition: all 200ms ease;
+
+    &:hover {
+      background: var(--surface-card-hover);
+      color: var(--text-primary);
+    }
+
+    &.active {
+      background: var(--gradient-brand);
+      color: var(--text-inverse);
+      border-color: transparent;
+    }
+  }
+}
+
+.type-chart-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.chart-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+
+  .search-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 8px;
+    background: var(--surface-card);
+    border: 1px solid var(--border-subtle);
+
+    mat-icon {
+      color: var(--text-tertiary);
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    input {
+      background: transparent;
+      border: none;
+      outline: none;
+      color: var(--text-primary);
+      font-size: 0.9rem;
+      width: 180px;
+
+      &::placeholder {
+        color: var(--text-tertiary);
+      }
+    }
+  }
+
+  .view-toggle {
+    display: flex;
+    gap: 8px;
+
+    button {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 16px;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      background: var(--surface-card);
+      color: var(--text-secondary);
+      border: 1px solid var(--border-subtle);
+      transition: all 200ms ease;
+
+      &:hover {
+        background: var(--surface-card-hover);
+        color: var(--text-primary);
+      }
+
+      &.active {
+        background: var(--gradient-brand);
+        color: var(--text-inverse);
+        border-color: transparent;
+      }
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+}
+
+.type-chart-wrapper {
+  overflow-x: auto;
+  padding: 16px;
+  background: var(--surface-card);
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+}
+
+.type-chart-grid {
+  display: grid;
+  grid-template-columns: repeat(19, auto);
+  gap: 2px;
+  min-width: max-content;
+}
+
+.corner-cell {
+  width: 100px;
+  height: 40px;
+}
+
+.header-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+
+  &.attacking-header {
+    width: 100px;
+    justify-content: flex-start;
+    padding-left: 8px;
+  }
+
+  &.defending-header {
+    height: 40px;
+  }
+}
+
+.effectiveness-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 32px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 150ms ease;
+
+  &:hover {
+    transform: scale(1.1);
+    z-index: 1;
+  }
+
+  &.highlighted {
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.5);
+  }
+
+  &.row-selected {
+    box-shadow: 0 0 0 1px rgba(139, 92, 246, 0.3);
+  }
+
+  &.column-selected {
+    box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.3);
+  }
+}
+
+.cell-none {
+  background: #4a4a4a;
+  color: #d4d4d4;
+}
+
+.cell-very-resistant {
+  background: #1a4d2e;
+  color: #86efac;
+}
+
+.cell-resistant {
+  background: #2d6a4f;
+  color: #4ade80;
+}
+
+.cell-neutral {
+  background: #2a2d3a;
+  color: #a3a3a3;
+}
+
+.cell-super-effective {
+  background: #7c4a03;
+  color: #fbbf24;
+}
+
+.cell-very-super-effective {
+  background: #991b1b;
+  color: #f87171;
+}
+
+.type-info-panel {
+  background: var(--surface-card);
+  border-radius: 12px;
+  padding: 24px;
+  border: 1px solid var(--border-subtle);
+
+  h3 {
+    margin: 0 0 20px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  &.defensive-panel {
+    .defensive-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+
+      h3 {
+        margin: 0;
+      }
+
+      .selected-types {
+        display: flex;
+        gap: 8px;
+      }
+    }
+  }
+}
+
+.hover-tooltip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: var(--surface-card);
+  border-radius: 10px;
+  border: 1px solid var(--border-default);
+  box-shadow: var(--shadow-elevated);
+  animation: tooltipFadeIn 150ms ease-out;
+
+  .tooltip-arrow {
+    color: var(--text-tertiary);
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .tooltip-result {
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 4px 12px;
+    border-radius: 6px;
+
+    &.cell-super-effective, &.cell-very-super-effective {
+      color: var(--color-warning);
+      background: var(--color-warning-bg);
+    }
+
+    &.cell-resistant, &.cell-very-resistant {
+      color: var(--color-success);
+      background: var(--color-success-bg);
+    }
+
+    &.cell-none {
+      color: var(--text-tertiary);
+      background: rgba(74, 74, 74, 0.3);
+    }
+
+    &.cell-neutral {
+      color: var(--text-secondary);
+      background: rgba(163, 163, 163, 0.1);
+    }
+  }
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.matchup-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.matchup-group {
+  h4 {
+    margin: 0 0 12px 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  .empty-msg {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    font-style: italic;
+  }
+}
+
+.type-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.calculator-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+
+.calculator-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--surface-card);
+  padding: 24px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+
+  button {
+    margin-top: 8px;
+  }
+}
+
+.damage-result {
+  background: var(--surface-card);
+  padding: 32px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  text-align: center;
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+}
+
+.effectiveness-badge {
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+
+  &.super-effective {
+    background: var(--color-warning-bg);
+    color: var(--color-warning);
+    border: 1px solid var(--color-warning);
+  }
+
+  &.not-effective {
+    background: var(--color-success-bg);
+    color: var(--color-success);
+    border: 1px solid var(--color-success);
+  }
+
+  &.neutral {
+    background: rgba(163, 163, 163, 0.15);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-default);
+  }
+}
+
+.result-value {
+  margin-bottom: 16px;
+}
+
+.damage-number {
+  font-size: 3.5rem;
+  font-weight: 700;
+  background: var(--gradient-brand);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.damage-label {
+  display: block;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.result-details {
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+  }
+}
+
+::ng-deep .calculator-form .mat-mdc-form-field {
+  .mat-mdc-text-field-wrapper {
+    --mdc-outlined-text-field-outline-color: rgba(255, 255, 255, 0.12);
+    --mdc-outlined-text-field-hover-outline-color: rgba(139, 92, 246, 0.5);
+    --mdc-outlined-text-field-focused-outline-color: #8b5cf6;
+    background: #252830;
+  }
+
+  .mat-mdc-form-field-label {
+    color: #a3a3a3;
+  }
+
+  .mat-mdc-select-value {
+    color: #e5e5e5;
+  }
+
+  .mat-mdc-input-element {
+    color: #e5e5e5;
+  }
+}
+
+::ng-deep .calculator-form .mat-mdc-option {
+  background: #252830;
+  color: #e5e5e5;
+
+  &.mdc-list-item--selected {
+    background: #3a3d4a;
+  }
+
+  &:hover {
+    background: #2a2d3a;
+  }
+}
+
+::ng-deep .calculator-form .mat-mdc-select-panel {
+  background: #252830;
+}
+
+.damage-result {
+  background: var(--surface-card, #1a1d27);
+  padding: 32px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  text-align: center;
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary, #e5e5e5);
+  }
+}
+
+.effectiveness-badge {
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+
+  &.super-effective {
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+    border: 1px solid rgba(251, 191, 36, 0.3);
+  }
+
+  &.not-effective {
+    background: rgba(74, 222, 128, 0.15);
+    color: #4ade80;
+    border: 1px solid rgba(74, 222, 128, 0.3);
+  }
+
+  &.neutral {
+    background: rgba(163, 163, 163, 0.15);
+    color: #a3a3a3;
+    border: 1px solid rgba(163, 163, 163, 0.3);
+  }
+}
+
+.result-value {
+  margin-bottom: 16px;
+}
+
+.damage-number {
+  font-size: 3.5rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #8b5cf6 0%, #6366f1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.damage-label {
+  display: block;
+  font-size: 1rem;
+  color: var(--text-secondary, #a3a3a3);
+  margin-top: 4px;
+}
+
+.result-details {
+  p {
+    margin: 0;
+    color: var(--text-secondary, #a3a3a3);
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 1200px) {
+  .calculator-section {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .battle-strategy-container {
+    padding: 16px;
+  }
+
+  .tab-switcher {
+    flex-direction: column;
+    align-items: stretch;
+
+    button {
+      justify-content: center;
+    }
+  }
+
+  .type-chart-wrapper {
+    padding: 12px;
+  }
+
+  .matchup-groups {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/battle-strategy/battle-strategy.component.ts
+++ b/src/app/battle-strategy/battle-strategy.component.ts
@@ -1,0 +1,253 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { ReactiveFormsModule, FormBuilder, FormsModule } from '@angular/forms';
+import { DataServiceService } from '../services/data-service.service';
+import { TypeDetail } from '../shared/pokemon-api.interfaces';
+import { TypeBadgeComponent } from '../shared/components/type-badge/type-badge.component';
+import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
+import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
+import { catchError, of } from 'rxjs';
+
+const TYPES = ['normal', 'fire', 'water', 'electric', 'grass', 'ice', 'fighting', 'poison', 'ground', 'flying', 'psychic', 'bug', 'rock', 'ghost', 'dragon', 'dark', 'steel', 'fairy'];
+
+interface TypeHoverInfo {
+  attackingType: string;
+  defendingType: string;
+  effectiveness: number;
+  label: string;
+}
+
+@Component({
+  selector: 'app-battle-strategy',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSelectModule,
+    MatInputModule,
+    MatFormFieldModule,
+    ReactiveFormsModule,
+    FormsModule,
+    TypeBadgeComponent,
+    PokeballSpinnerComponent,
+    PageHeaderComponent
+  ],
+  templateUrl: './battle-strategy.component.html',
+  styleUrl: './battle-strategy.component.scss'
+})
+export class BattleStrategyComponent implements OnInit {
+  private dataService = inject(DataServiceService);
+  private fb = inject(FormBuilder);
+
+  readonly types = TYPES;
+  readonly activeTab = signal<'chart' | 'calculator'>('chart');
+  readonly typeDetails = signal<TypeDetail[]>([]);
+  readonly loading = signal(true);
+  readonly selectedType = signal<string | null>(null);
+  readonly selectedDefensiveTypes = signal<string[]>([]);
+  readonly damageResult = signal<{ damage: number; effectiveness: number; label: string } | null>(null);
+  readonly hoveredCell = signal<TypeHoverInfo | null>(null);
+  readonly typeSearch = signal('');
+
+  filteredTypes = computed(() => {
+    const search = this.typeSearch().toLowerCase();
+    if (!search) return this.types;
+    return this.types.filter(t => t.includes(search));
+  });
+
+  moveRecommendations = computed(() => {
+    const selected = this.selectedType();
+    if (!selected) return { strongAgainst: [], weakAgainst: [], resistantTo: [], weakTo: [] };
+
+    const details = this.typeDetails();
+    const typeDetail = details.find(t => t.name === selected);
+    if (!typeDetail) return { strongAgainst: [], weakAgainst: [], resistantTo: [], weakTo: [] };
+
+    const strongAgainst = typeDetail.damage_relations.double_damage_to.map(t => t.name);
+    const weakAgainst = typeDetail.damage_relations.half_damage_to.map(t => t.name)
+      .concat(typeDetail.damage_relations.no_damage_to.map(t => t.name));
+    const weakTo = typeDetail.damage_relations.double_damage_from.map(t => t.name);
+    const resistantTo = typeDetail.damage_relations.half_damage_from.map(t => t.name)
+      .concat(typeDetail.damage_relations.no_damage_from.map(t => t.name));
+
+    return { strongAgainst, weakAgainst, resistantTo, weakTo };
+  });
+
+  defensiveMatchups = computed(() => {
+    const selected = this.selectedDefensiveTypes();
+    if (selected.length === 0) return { weakTo: [], resistantTo: [], immuneTo: [], neutralTo: [] };
+
+    const details = this.typeDetails();
+    const effectivenessMap = new Map<string, number>();
+
+    for (const defType of selected) {
+      const typeDetail = details.find(t => t.name === defType);
+      if (!typeDetail) continue;
+
+      for (const atkType of TYPES) {
+        const atkDetail = details.find(t => t.name === atkType);
+        if (!atkDetail) continue;
+
+        let eff = 1;
+        if (atkDetail.damage_relations.double_damage_to.some(t => t.name === defType)) eff = 2;
+        else if (atkDetail.damage_relations.half_damage_to.some(t => t.name === defType)) eff = 0.5;
+        else if (atkDetail.damage_relations.no_damage_to.some(t => t.name === defType)) eff = 0;
+
+        const current = effectivenessMap.get(atkType) ?? 1;
+        effectivenessMap.set(atkType, current * eff);
+      }
+    }
+
+    const weakTo: string[] = [];
+    const resistantTo: string[] = [];
+    const immuneTo: string[] = [];
+    const neutralTo: string[] = [];
+
+    effectivenessMap.forEach((eff, type) => {
+      if (eff === 0) immuneTo.push(type);
+      else if (eff < 1) resistantTo.push(type);
+      else if (eff > 1) weakTo.push(type);
+      else neutralTo.push(type);
+    });
+
+    return { weakTo, resistantTo, immuneTo, neutralTo };
+  });
+
+  calculatorForm = this.fb.group({
+    attackingType: ['fire'],
+    defendingTypes: [['normal']],
+    power: [80],
+    level: [50]
+  });
+
+  ngOnInit(): void {
+    this.dataService.getAllTypesWithDetails().pipe(
+      catchError((error) => {
+        console.error('Error loading type details:', error);
+        return of([]);
+      })
+    ).subscribe((details) => {
+      this.typeDetails.set(details);
+      this.loading.set(false);
+    });
+  }
+
+  getEffectiveness(attackingType: string, defendingType: string): number {
+    const details = this.typeDetails();
+    const typeDetail = details.find(t => t.name === attackingType);
+    if (!typeDetail) return 1;
+
+    const relations = typeDetail.damage_relations;
+
+    if (relations.no_damage_to.some(t => t.name === defendingType)) return 0;
+    if (relations.half_damage_to.some(t => t.name === defendingType)) return 0.5;
+    if (relations.double_damage_to.some(t => t.name === defendingType)) return 2;
+
+    return 1;
+  }
+
+  getCellClass(effectiveness: number): string {
+    if (effectiveness === 0) return 'cell-none';
+    if (effectiveness === 0.25) return 'cell-very-resistant';
+    if (effectiveness === 0.5) return 'cell-resistant';
+    if (effectiveness === 1) return 'cell-neutral';
+    if (effectiveness === 2) return 'cell-super-effective';
+    if (effectiveness === 4) return 'cell-very-super-effective';
+    return 'cell-neutral';
+  }
+
+  getEffectivenessLabel(effectiveness: number): string {
+    if (effectiveness === 0) return '0x';
+    if (effectiveness === 0.25) return '0.25x';
+    if (effectiveness === 0.5) return '0.5x';
+    if (effectiveness === 1) return '1x';
+    if (effectiveness === 2) return '2x';
+    if (effectiveness === 4) return '4x';
+    return '1x';
+  }
+
+  getHoverLabel(effectiveness: number): string {
+    if (effectiveness === 0) return 'No effect';
+    if (effectiveness === 0.25) return 'Very resistant';
+    if (effectiveness === 0.5) return 'Resistant';
+    if (effectiveness === 1) return 'Neutral';
+    if (effectiveness === 2) return 'Super effective';
+    if (effectiveness === 4) return 'Very super effective';
+    return 'Neutral';
+  }
+
+  selectType(type: string): void {
+    this.selectedType.set(this.selectedType() === type ? null : type);
+  }
+
+  isTypeSelected(type: string): boolean {
+    return this.selectedType() === type;
+  }
+
+  toggleDefensiveType(type: string): void {
+    const current = this.selectedDefensiveTypes();
+    if (current.includes(type)) {
+      this.selectedDefensiveTypes.set(current.filter(t => t !== type));
+    } else if (current.length < 2) {
+      this.selectedDefensiveTypes.set([...current, type]);
+    }
+  }
+
+  isDefensiveTypeSelected(type: string): boolean {
+    return this.selectedDefensiveTypes().includes(type);
+  }
+
+  clearDefensiveSelection(): void {
+    this.selectedDefensiveTypes.set([]);
+  }
+
+  calculateDamage(): void {
+    const formValue = this.calculatorForm.value;
+    const attackingType = formValue.attackingType || 'normal';
+    const defendingTypes = formValue.defendingTypes || ['normal'];
+    const power = formValue.power || 80;
+    const level = formValue.level || 50;
+
+    let effectiveness = 1;
+    for (const defType of defendingTypes) {
+      effectiveness *= this.getEffectiveness(attackingType, defType);
+    }
+
+    const attack = 100;
+    const defense = 100;
+    const damage = ((2 * level / 5 + 2) * power * attack / defense / 50 + 2) * effectiveness;
+
+    let label = 'Normal damage';
+    if (effectiveness === 0) label = 'No effect';
+    else if (effectiveness < 1) label = 'Not very effective';
+    else if (effectiveness > 1) label = 'Super effective!';
+
+    this.damageResult.set({ damage: Math.round(damage), effectiveness, label });
+  }
+
+  setActiveTab(tab: 'chart' | 'calculator'): void {
+    this.activeTab.set(tab);
+  }
+
+  onCellHover(atkType: string, defType: string): void {
+    const eff = this.getEffectiveness(atkType, defType);
+    this.hoveredCell.set({
+      attackingType: atkType,
+      defendingType: defType,
+      effectiveness: eff,
+      label: this.getHoverLabel(eff)
+    });
+  }
+
+  onCellLeave(): void {
+    this.hoveredCell.set(null);
+  }
+}

--- a/src/app/evolution-chains/evolution-chains.component.html
+++ b/src/app/evolution-chains/evolution-chains.component.html
@@ -1,0 +1,97 @@
+<div class="evolution-chains-container">
+  <ds-page-header
+    title="Evolution Chains"
+    subtitle="Explore how Pokémon evolve across all families">
+  </ds-page-header>
+
+  <div class="controls-section">
+    <mat-form-field class="search-field" appearance="outline">
+      <mat-icon matPrefix>search</mat-icon>
+      <input
+        matInput
+        [formControl]="searchControl"
+        placeholder="Search by Pokémon name..."
+        type="text"
+        autocomplete="off" />
+      @if (searchControl.value) {
+        <button matSuffix mat-icon-button aria-label="Clear" (click)="searchControl.setValue('')">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+    </mat-form-field>
+
+    <div class="trigger-filters">
+      @if (triggerLoading()) {
+        <div class="trigger-skeleton-chips">
+          @for (i of [1, 2, 3, 4, 5]; track i) {
+            <div class="trigger-chip skeleton"></div>
+          }
+        </div>
+      } @else {
+        @for (trigger of triggers(); track trigger.id) {
+          <button
+            class="trigger-chip"
+            [class.active]="selectedTrigger() === trigger.name"
+            (click)="onTriggerFilter(trigger.name)">
+            <mat-icon>{{ getTriggerIcon(trigger.name) }}</mat-icon>
+            <span>{{ getTriggerLabel(trigger.name) }}</span>
+          </button>
+        }
+      }
+    </div>
+  </div>
+
+  @if (loading()) {
+    <div class="chains-grid">
+      @for (i of [1, 2, 3, 4, 5, 6, 7, 8]; track i) {
+        <ds-skeleton-card size="md"></ds-skeleton-card>
+      }
+    </div>
+  } @else if (isSearching() && displayChains().length === 0) {
+    <ds-empty-state
+      icon="search_off"
+      title="No evolution chains found"
+      [message]="'No results for \'' + searchControl.value + '\''">
+    </ds-empty-state>
+  } @else if (!hasResults() && !loading()) {
+    <ds-empty-state
+      icon="sync_disabled"
+      title="No evolution chains available"
+      message="Try again later">
+    </ds-empty-state>
+  } @else {
+    <div class="chains-grid">
+      @for (chain of displayChains(); track chain.chainId) {
+        <div class="chain-card" (click)="onChainClick(chain.basePokemonId)">
+          <div class="chain-card-image">
+            <img [src]="chain.spriteUrl" [alt]="chain.basePokemonName" loading="lazy" />
+            <div class="chain-card-badge">#{{ chain.chainId }}</div>
+          </div>
+          <div class="chain-card-content">
+            <h3 class="chain-card-name">{{ chain.basePokemonName }}</h3>
+            <div class="chain-card-meta">
+              <span class="chain-stages">
+                <mat-icon>account_tree</mat-icon>
+                {{ chain.totalStages }} stage{{ chain.totalStages > 1 ? 's' : '' }}
+              </span>
+              @if (chain.branchCount > 0) {
+                <span class="chain-branches">
+                  <mat-icon>fork_right</mat-icon>
+                  {{ chain.branchCount }} branch{{ chain.branchCount > 1 ? 'es' : '' }}
+                </span>
+              }
+            </div>
+          </div>
+        </div>
+      }
+    </div>
+
+    @if (loadingMore()) {
+      <div class="loading-more">
+        <ds-pokeball-spinner [size]="48" label="Loading more..."></ds-pokeball-spinner>
+      </div>
+    }
+  }
+
+  <div #scrollAnchor class="scroll-anchor"></div>
+</div>

--- a/src/app/evolution-chains/evolution-chains.component.scss
+++ b/src/app/evolution-chains/evolution-chains.component.scss
@@ -1,0 +1,228 @@
+.evolution-chains-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px 60px;
+}
+
+.controls-section {
+  margin-bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.search-field {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+}
+
+.trigger-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.trigger-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: 1px solid var(--border, #e4e4e4);
+  border-radius: 24px;
+  background: var(--surface, #ffffff);
+  color: var(--text-secondary, #525252);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: var(--primary, #8b5cf6);
+    color: var(--primary, #8b5cf6);
+    background: rgba(139, 92, 246, 0.05);
+  }
+
+  &.active {
+    border-color: var(--primary, #8b5cf6);
+    background: var(--primary, #8b5cf6);
+    color: #ffffff;
+
+    mat-icon {
+      color: #ffffff;
+    }
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &.skeleton {
+    width: 100px;
+    height: 36px;
+    background: linear-gradient(90deg, var(--gray-100, #f4f4f4) 25%, var(--gray-200, #e4e4e4) 50%, var(--gray-100, #f4f4f4) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+    border: none;
+    cursor: default;
+  }
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.chains-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.chain-card {
+  background: var(--surface-card, #ffffff);
+  border: 1px solid var(--border, #e4e4e4);
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+    border-color: var(--primary, #8b5cf6);
+
+    .chain-card-image::after {
+      opacity: 0.1;
+    }
+  }
+}
+
+.chain-card-image {
+  position: relative;
+  height: 200px;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--primary, #8b5cf6);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  img {
+    width: 140px;
+    height: 140px;
+    object-fit: contain;
+    z-index: 1;
+    transition: transform 0.3s ease;
+  }
+
+  &:hover img {
+    transform: scale(1.1);
+  }
+}
+
+.chain-card-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #ffffff;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  z-index: 2;
+}
+
+.chain-card-content {
+  padding: 16px;
+}
+
+.chain-card-name {
+  margin: 0 0 8px;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary, #171717);
+  letter-spacing: -0.01em;
+}
+
+.chain-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.chain-stages,
+.chain-branches {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8125rem;
+  color: var(--text-secondary, #525252);
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: var(--primary, #8b5cf6);
+  }
+}
+
+.loading-more {
+  display: flex;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.scroll-anchor {
+  height: 1px;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .evolution-chains-container {
+    padding: 0 16px 40px;
+  }
+
+  .chains-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+  }
+
+  .chain-card-image {
+    height: 160px;
+
+    img {
+      width: 110px;
+      height: 110px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .chains-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .trigger-chip {
+    padding: 6px 12px;
+    font-size: 0.8125rem;
+  }
+}

--- a/src/app/evolution-chains/evolution-chains.component.ts
+++ b/src/app/evolution-chains/evolution-chains.component.ts
@@ -1,0 +1,276 @@
+import { Component, OnInit, inject, signal, computed, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { ReactiveFormsModule, FormBuilder, FormControl } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, switchMap, map, catchError, of, forkJoin, finalize, Subscription } from 'rxjs';
+import { DataServiceService } from '../services/data-service.service';
+import { EvolutionChain, EvolutionChainLink, EvolutionTriggerDetail } from '../shared/pokemon-api.interfaces';
+import { SkeletonCardComponent } from '../shared/components/skeleton-card/skeleton-card.component';
+import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
+import { EmptyStateComponent } from '../shared/components/empty-state/empty-state.component';
+import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
+import { capitalize, extractPokemonId, getOfficialArtworkUrl } from '../shared/utils/pokemon.utils';
+
+interface ChainPreview {
+  chainId: number;
+  basePokemonName: string;
+  basePokemonId: number;
+  spriteUrl: string;
+  totalStages: number;
+  branchCount: number;
+}
+
+@Component({
+  selector: 'app-evolution-chains',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    ReactiveFormsModule,
+    SkeletonCardComponent,
+    PokeballSpinnerComponent,
+    EmptyStateComponent,
+    PageHeaderComponent
+  ],
+  templateUrl: './evolution-chains.component.html',
+  styleUrls: ['./evolution-chains.component.scss']
+})
+export class EvolutionChainsComponent implements OnInit, AfterViewInit, OnDestroy {
+  private dataService = inject(DataServiceService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+
+  @ViewChild('scrollAnchor') scrollAnchor!: ElementRef;
+
+  searchControl = new FormControl('');
+  chains = signal<ChainPreview[]>([]);
+  loading = signal<boolean>(false);
+  loadingMore = signal<boolean>(false);
+  hasMore = signal<boolean>(true);
+  totalCount = signal<number>(0);
+  selectedTrigger = signal<string | null>(null);
+  searchResults = signal<ChainPreview[]>([]);
+  isSearching = signal<boolean>(false);
+  triggers = signal<EvolutionTriggerDetail[]>([]);
+  triggerLoading = signal<boolean>(false);
+
+  private offset = 0;
+  private readonly limit = 20;
+  private searchSubscription = new Subscription();
+  private observer: IntersectionObserver | null = null;
+
+  displayChains = computed(() => {
+    if (this.isSearching()) {
+      return this.searchResults();
+    }
+    return this.chains();
+  });
+
+  hasResults = computed(() => this.displayChains().length > 0);
+
+  ngOnInit(): void {
+    this.loadTriggers();
+    this.loadChains();
+    this.setupSearch();
+  }
+
+  ngAfterViewInit(): void {
+    this.setupIntersectionObserver();
+  }
+
+  ngOnDestroy(): void {
+    this.searchSubscription.unsubscribe();
+    this.observer?.disconnect();
+  }
+
+  private loadTriggers(): void {
+    this.triggerLoading.set(true);
+    this.dataService.getEvolutionTriggers().pipe(
+      catchError(() => of([])),
+      finalize(() => this.triggerLoading.set(false))
+    ).subscribe(triggers => this.triggers.set(triggers));
+  }
+
+  private loadChains(): void {
+    if (this.loadingMore() || !this.hasMore() || this.loading() || this.isSearching()) return;
+
+    if (this.offset === 0) {
+      this.loading.set(true);
+    } else {
+      this.loadingMore.set(true);
+    }
+
+    this.dataService.getAllEvolutionChains(this.limit, this.offset).pipe(
+      switchMap(response => {
+        this.totalCount.set(response.count);
+        this.hasMore.set(!!response.next);
+        const chainUrls = response.results;
+        const requests = chainUrls.map(item => {
+          const id = extractPokemonId(item.url);
+          return this.dataService.getEvolutionChainById(id);
+        });
+        return forkJoin(requests);
+      }),
+      map(chains => {
+        const previews: ChainPreview[] = chains
+          .filter(chain => chain && chain.id && chain.chain)
+          .map(chain => this.buildChainPreview(chain));
+        return previews;
+      }),
+      catchError(() => of([])),
+      finalize(() => {
+        this.loading.set(false);
+        this.loadingMore.set(false);
+      })
+    ).subscribe(previews => {
+      if (this.offset === 0) {
+        this.chains.set(previews);
+      } else {
+        this.chains.update(current => [...current, ...previews]);
+      }
+      this.offset += this.limit;
+    });
+  }
+
+  private buildChainPreview(chain: EvolutionChain): ChainPreview {
+    const baseSpecies = chain.chain.species;
+    const basePokemonId = extractPokemonId(baseSpecies.url);
+    const totalStages = this.countStages(chain.chain);
+    const branchCount = this.countBranches(chain.chain);
+    return {
+      chainId: chain.id,
+      basePokemonName: capitalize(baseSpecies.name),
+      basePokemonId,
+      spriteUrl: getOfficialArtworkUrl(basePokemonId),
+      totalStages,
+      branchCount
+    };
+  }
+
+  private countStages(link: EvolutionChainLink): number {
+    if (!link.evolves_to || link.evolves_to.length === 0) return 1;
+    let maxDepth = 0;
+    for (const evolution of link.evolves_to) {
+      const depth = this.countStages(evolution);
+      if (depth > maxDepth) maxDepth = depth;
+    }
+    return 1 + maxDepth;
+  }
+
+  private countBranches(link: EvolutionChainLink): number {
+    if (!link.evolves_to || link.evolves_to.length === 0) return 0;
+    let branches = link.evolves_to.length > 1 ? 1 : 0;
+    for (const evolution of link.evolves_to) {
+      branches += this.countBranches(evolution);
+    }
+    return branches;
+  }
+
+  private setupSearch(): void {
+    this.searchSubscription = this.searchControl.valueChanges.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(query => {
+        if (!query || query.trim().length === 0) {
+          this.isSearching.set(false);
+          this.searchResults.set([]);
+          return of([]);
+        }
+        this.isSearching.set(true);
+        return this.dataService.searchPokemonByName(query).pipe(
+          switchMap(results => {
+            if (results.length === 0) return of([]);
+            const requests = results.slice(0, 20).map(pokemon => {
+              const id = extractPokemonId(pokemon.url);
+              return this.dataService.getPokemonSpecies(id);
+            });
+            return forkJoin(requests);
+          }),
+          switchMap(speciesList => {
+            const chainUrls = speciesList
+              .filter(s => s && s.evolution_chain)
+              .map(s => s.evolution_chain?.url ?? '');
+            const uniqueUrls = [...new Set(chainUrls)];
+            if (uniqueUrls.length === 0) return of([]);
+            const requests = uniqueUrls.map(url => {
+              const id = extractPokemonId(url);
+              return this.dataService.getEvolutionChainById(id);
+            });
+            return forkJoin(requests);
+          }),
+          map(chains => {
+            const previews: ChainPreview[] = chains
+              .filter(chain => chain && chain.id && chain.chain)
+              .map(chain => this.buildChainPreview(chain));
+            return previews;
+          }),
+          catchError(() => of([]))
+        );
+      })
+    ).subscribe(previews => {
+      this.searchResults.set(previews);
+    });
+  }
+
+  private setupIntersectionObserver(): void {
+    this.observer = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && this.hasMore() && !this.loadingMore() && !this.loading()) {
+        this.loadChains();
+      }
+    }, { rootMargin: '200px' });
+
+    if (this.scrollAnchor?.nativeElement) {
+      this.observer.observe(this.scrollAnchor.nativeElement);
+    }
+  }
+
+  onTriggerFilter(triggerName: string): void {
+    if (this.selectedTrigger() === triggerName) {
+      this.selectedTrigger.set(null);
+    } else {
+      this.selectedTrigger.set(triggerName);
+    }
+  }
+
+  onChainClick(chainId: number): void {
+    this.router.navigate(['/photo', chainId]);
+  }
+
+  getTriggerLabel(triggerName: string): string {
+    const labels: Record<string, string> = {
+      'level-up': 'Level Up',
+      'trade': 'Trade',
+      'use-item': 'Use Item',
+      'shed': 'Shed',
+      'other': 'Other'
+    };
+    return labels[triggerName] || capitalize(triggerName);
+  }
+
+  getTriggerIcon(triggerName: string): string {
+    const icons: Record<string, string> = {
+      'level-up': 'trending_up',
+      'trade': 'swap_horiz',
+      'use-item': 'science',
+      'shed': 'bug_report',
+      'other': 'more_horiz'
+    };
+    return icons[triggerName] || 'help_outline';
+  }
+
+  onScroll(): void {
+    const pos = (document.documentElement.scrollTop || document.body.scrollTop) + window.innerHeight;
+    const max = document.documentElement.scrollHeight || document.body.scrollHeight;
+    if (max - pos <= 500 && this.hasMore() && !this.loadingMore() && !this.loading() && !this.isSearching()) {
+      this.loadChains();
+    }
+  }
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -63,12 +63,12 @@
         <div class="stat-label">Pokémon</div>
       </div>
       <div class="stat-item">
-        <div class="stat-number">6</div>
-        <div class="stat-label">Team Size</div>
-      </div>
-      <div class="stat-item">
         <div class="stat-number">18</div>
         <div class="stat-label">Types</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-number">9</div>
+        <div class="stat-label">Regions</div>
       </div>
       <div class="stat-item">
         <div class="stat-number">∞</div>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -11,7 +11,7 @@
   padding: 56px 40px;
   min-height: 460px;
   gap: 40px;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  background: var(--bg-secondary);
   border-radius: 0 0 20px 20px;
   margin-bottom: 48px;
   position: relative;
@@ -90,7 +90,7 @@
       opacity: 0.85;
       max-width: 500px;
       font-weight: 400;
-      color: rgba(255, 255, 255, 0.8);
+      color: var(--text-secondary);
     }
 
     .hero-actions {
@@ -247,10 +247,10 @@
 
 .stats {
   padding: 40px;
-  background: linear-gradient(135deg, #fafafa 0%, #f4f4f4 100%);
+  background: var(--bg-secondary);
   border-radius: 16px;
   margin: 0 40px 56px;
-  border: 0.5px solid var(--border-subtle, rgba(0, 0, 0, 0.06));
+  border: 0.5px solid var(--border-subtle);
 
   .stats-grid {
     display: grid;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -34,16 +34,10 @@ export class HomeComponent {
       route: '/catalog'
     },
     {
-      icon: 'search',
-      title: 'Search by ID',
-      description: 'Find any Pokémon instantly by ID number',
-      route: '/catalog'
-    },
-    {
-      icon: 'book',
-      title: 'Regional Pokédex',
-      description: 'Browse Pokémon by region: Kanto, Johto, Paldea and more',
-      route: '/catalog'
+      icon: 'account_tree',
+      title: 'Evolution Chains',
+      description: 'Explore how Pokémon evolve across all 500+ families',
+      route: '/evolution-chains'
     },
     {
       icon: 'menu_book',
@@ -58,6 +52,36 @@ export class HomeComponent {
       route: '/abilities'
     },
     {
+      icon: 'swords',
+      title: 'Battle Strategy',
+      description: 'Type effectiveness chart and damage calculator',
+      route: '/battle-strategy'
+    },
+    {
+      icon: 'category',
+      title: 'Types Deep Dive',
+      description: 'Explore all 18 types with matchups, Pokémon, and moves',
+      route: '/types'
+    },
+    {
+      icon: 'map',
+      title: 'Locations',
+      description: 'Find where Pokémon live across 9 regions',
+      route: '/locations'
+    },
+    {
+      icon: 'psychology_alt',
+      title: 'Natures & Stats',
+      description: 'Understand natures, growth rates, and characteristics',
+      route: '/natures'
+    },
+    {
+      icon: 'compare_arrows',
+      title: 'Compare Pokémon',
+      description: 'Side-by-side stat comparison of any two Pokémon',
+      route: '/compare'
+    },
+    {
       icon: 'groups',
       title: 'Build Your Team',
       description: 'Create and manage your ultimate Pokémon team of 6',
@@ -70,10 +94,10 @@ export class HomeComponent {
       route: '/team'
     },
     {
-      icon: 'compare_arrows',
-      title: 'Compare Pokémon',
-      description: 'Side-by-side stat comparison of any two Pokémon',
-      route: '/compare'
+      icon: 'favorite',
+      title: 'Favorites',
+      description: 'Save up to 50 favorite Pokémon for quick access',
+      route: '/favorites'
     }
   ];
 }

--- a/src/app/locations/locations.component.html
+++ b/src/app/locations/locations.component.html
@@ -1,0 +1,105 @@
+<div class="locations-container">
+  <ds-page-header title="Locations" subtitle="Explore regions and where to find Pokémon"></ds-page-header>
+
+  <div class="search-section">
+    <mat-form-field appearance="outline" class="search-field">
+      <mat-label>Search locations</mat-label>
+      <input matInput [formControl]="searchControl" placeholder="Enter location name..." />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+  </div>
+
+  <div class="region-chips">
+    <button
+      mat-button
+      [class.active]="selectedRegion() === 'all'"
+      (click)="selectRegion('all')"
+    >
+      <mat-icon>public</mat-icon>
+      All Regions
+    </button>
+    @for (region of filteredRegions(); track region.name) {
+      <button
+        mat-button
+        [class.active]="selectedRegion() === region.name"
+        (click)="selectRegion(region.name)"
+      >
+        <mat-icon>{{ region.icon }}</mat-icon>
+        {{ region.displayName }}
+      </button>
+    }
+  </div>
+
+  @if (loadingLocations()) {
+    <div class="loading-container">
+      <ds-pokeball-spinner [size]="60" label="Loading locations..."></ds-pokeball-spinner>
+    </div>
+  } @else if (filteredLocations().length === 0) {
+    <ds-empty-state
+      icon="location_off"
+      title="No locations found"
+      message="Try adjusting your search or selecting a different region"
+    ></ds-empty-state>
+  } @else {
+    <div class="locations-list">
+      @for (location of filteredLocations(); track location.id) {
+        <div class="location-card" [class.expanded]="expandedLocationId() === location.id">
+          <div class="location-header" (click)="toggleLocation(location)">
+            <div class="location-info">
+              <h3 class="location-name">{{ location.name | titlecase }}</h3>
+              <span class="location-region">{{ location.region | titlecase }}</span>
+            </div>
+            <div class="location-meta">
+              <span class="area-count">{{ location.areaCount }} area{{ location.areaCount !== 1 ? 's' : '' }}</span>
+              <mat-icon class="expand-icon">
+                {{ expandedLocationId() === location.id ? 'expand_less' : 'expand_more' }}
+              </mat-icon>
+            </div>
+          </div>
+
+          @if (expandedLocationId() === location.id) {
+            <div class="location-content">
+              @if (loadingArea() && !locationAreas()[location.id]) {
+                <div class="loading-areas">
+                  <ds-pokeball-spinner [size]="40" label="Loading areas..."></ds-pokeball-spinner>
+                </div>
+              } @else if (locationAreas()[location.id]) {
+                @for (area of locationAreas()[location.id]; track area.areaName) {
+                  <div class="area-section">
+                    <h4 class="area-name">{{ area.areaName | titlecase }}</h4>
+                    @if (area.pokemon.length === 0) {
+                      <p class="no-pokemon">No Pokémon found in this area</p>
+                    } @else {
+                      <div class="pokemon-grid">
+                        @for (p of area.pokemon; track p.name) {
+                          <div class="pokemon-encounter">
+                            <img
+                              [src]="p.spriteUrl"
+                              [alt]="p.name"
+                              class="pokemon-sprite"
+                              loading="lazy"
+                              (error)="onSpriteError($event, p.id)"
+                            />
+                            <span class="pokemon-name">{{ p.name | titlecase }}</span>
+                            <div class="encounter-details">
+                              <span class="max-chance">Max: {{ p.maxChance }}%</span>
+                              <div class="methods">
+                                @for (method of p.methods; track method) {
+                                  <span class="method-badge">{{ formatMethodName(method) }}</span>
+                                }
+                              </div>
+                            </div>
+                          </div>
+                        }
+                      </div>
+                    }
+                  </div>
+                }
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/src/app/locations/locations.component.scss
+++ b/src/app/locations/locations.component.scss
@@ -1,0 +1,297 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+
+.locations-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px 48px;
+}
+
+.search-section {
+  margin-bottom: 24px;
+
+  .search-field {
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+    display: block;
+
+    .mat-mdc-form-field-subscript-wrapper {
+      display: none;
+    }
+  }
+}
+
+.region-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 32px;
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 24px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-default);
+    transition: all 0.2s ease;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      background: var(--surface-card-hover);
+      border-color: #8b5cf6;
+      color: #8b5cf6;
+    }
+
+    &.active {
+      background: #8b5cf6;
+      border-color: #8b5cf6;
+      color: #fff;
+    }
+  }
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  padding: 80px 0;
+}
+
+.locations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.location-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+
+  &.expanded {
+    border-color: #8b5cf6;
+    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.1);
+  }
+}
+
+.location-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--surface-card-hover);
+  }
+}
+
+.location-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.location-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.location-region {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+.location-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.area-count {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  padding: 4px 10px;
+  border-radius: 12px;
+}
+
+.expand-icon {
+  color: var(--text-secondary);
+  transition: transform 0.2s ease;
+}
+
+.location-content {
+  border-top: 1px solid var(--border-default);
+  padding: 20px;
+  background: var(--bg-secondary);
+}
+
+.loading-areas {
+  display: flex;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.area-section {
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.area-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 16px 0;
+  text-transform: capitalize;
+}
+
+.no-pokemon {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-style: italic;
+  margin: 0;
+}
+
+.pokemon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.pokemon-encounter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 12px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-card-hover);
+  }
+}
+
+.pokemon-sprite {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-bottom: 8px;
+}
+
+.pokemon-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-transform: capitalize;
+  margin-bottom: 8px;
+}
+
+.encounter-details {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+.max-chance {
+  font-size: 0.8rem;
+  color: #8b5cf6;
+  font-weight: 600;
+}
+
+.methods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: center;
+}
+
+.method-badge {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+@media (max-width: 768px) {
+  .locations-container {
+    padding: 0 16px 32px;
+  }
+
+  .region-chips {
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 8px;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      height: 4px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--border-default);
+      border-radius: 2px;
+    }
+  }
+
+  .location-header {
+    padding: 14px 16px;
+  }
+
+  .location-name {
+    font-size: 1rem;
+  }
+
+  .location-content {
+    padding: 16px;
+  }
+
+  .pokemon-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
+  }
+
+  .pokemon-sprite {
+    width: 64px;
+    height: 64px;
+  }
+}
+
+@media (max-width: 480px) {
+  .pokemon-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/app/locations/locations.component.ts
+++ b/src/app/locations/locations.component.ts
@@ -1,0 +1,247 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { ReactiveFormsModule, FormBuilder, FormControl } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, switchMap, map, catchError, of, forkJoin } from 'rxjs';
+import { DataServiceService } from '../services/data-service.service';
+import { PokemonSummary, LocationDetail, LocationAreaDetail } from '../shared/pokemon-api.interfaces';
+import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
+import { EmptyStateComponent } from '../shared/components/empty-state/empty-state.component';
+import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
+
+interface LocationWithRegion {
+  id: number;
+  name: string;
+  region: string;
+  areaCount: number;
+}
+
+interface LocationAreaPokemon {
+  areaName: string;
+  pokemon: { name: string; id: number; spriteUrl: string; maxChance: number; methods: string[] }[];
+}
+
+const REGIONS = [
+  { id: 1, name: 'kanto', displayName: 'Kanto', icon: 'location_city' },
+  { id: 2, name: 'johto', displayName: 'Johto', icon: 'park' },
+  { id: 3, name: 'hoenn', displayName: 'Hoenn', icon: 'water' },
+  { id: 4, name: 'sinnoh', displayName: 'Sinnoh', icon: 'ac_unit' },
+  { id: 5, name: 'unova', displayName: 'Unova', icon: 'apartment' },
+  { id: 6, name: 'kalos', displayName: 'Kalos', icon: 'wb_sunny' },
+  { id: 7, name: 'alola', displayName: 'Alola', icon: 'beach_access' },
+  { id: 8, name: 'galar', displayName: 'Galar', icon: 'grass' },
+  { id: 9, name: 'paldea', displayName: 'Paldea', icon: 'landscape' },
+];
+
+@Component({
+  selector: 'app-locations',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatExpansionModule,
+    ReactiveFormsModule,
+    PokeballSpinnerComponent,
+    EmptyStateComponent,
+    PageHeaderComponent,
+  ],
+  templateUrl: './locations.component.html',
+  styleUrl: './locations.component.scss',
+})
+export class LocationsComponent implements OnInit {
+  private dataService = inject(DataServiceService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+
+  searchControl = new FormControl('');
+
+  selectedRegion = signal<string>('all');
+  locationsWithRegions = signal<LocationWithRegion[]>([]);
+  filteredLocations = signal<LocationWithRegion[]>([]);
+  loadingLocations = signal(true);
+  loadingArea = signal(false);
+  expandedLocationId = signal<number | null>(null);
+  locationAreas = signal<Record<number, LocationAreaPokemon[]>>({});
+  allPokemonCache = signal<Map<string, { id: number; spriteUrl: string }>>(new Map());
+
+  regions = REGIONS;
+
+  filteredRegions = computed(() => {
+    const search = this.searchControl.value?.toLowerCase() || '';
+    if (!search) return this.regions;
+    return this.regions.filter((r) => r.displayName.toLowerCase().includes(search));
+  });
+
+  ngOnInit(): void {
+    this.loadAllLocations();
+    this.setupSearch();
+  }
+
+  private setupSearch(): void {
+    this.searchControl.valueChanges
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+      )
+      .subscribe(() => {
+        this.applyFilters();
+      });
+  }
+
+  private loadAllLocations(): void {
+    this.loadingLocations.set(true);
+    this.dataService.getAllLocations().pipe(
+      switchMap((summaries: PokemonSummary[]) => {
+        const requests = summaries.map((s) => {
+          const id = parseInt(s.url.split('/').filter(Boolean).pop() ?? '0', 10);
+          return this.dataService.getLocationDetail(id).pipe(
+            map((detail: LocationDetail) => ({
+              id: detail.id,
+              name: detail.name,
+              region: detail.region?.name || 'unknown',
+              areaCount: detail.areas?.length || 0,
+            })),
+            catchError(() => of(null)),
+          );
+        });
+        return forkJoin(requests);
+      }),
+      map((results) => results.filter((r): r is LocationWithRegion => r !== null)),
+      catchError(() => of([])),
+    ).subscribe((locations: LocationWithRegion[]) => {
+      this.locationsWithRegions.set(locations);
+      this.applyFilters();
+      this.loadingLocations.set(false);
+    });
+  }
+
+  private applyFilters(): void {
+    const search = this.searchControl.value?.toLowerCase() || '';
+    const region = this.selectedRegion();
+    let filtered = this.locationsWithRegions();
+
+    if (region !== 'all') {
+      filtered = filtered.filter((l) => l.region === region);
+    }
+
+    if (search) {
+      filtered = filtered.filter((l) => l.name.toLowerCase().includes(search));
+    }
+
+    this.filteredLocations.set(filtered);
+  }
+
+  selectRegion(regionName: string): void {
+    this.selectedRegion.set(regionName);
+    this.applyFilters();
+  }
+
+  toggleLocation(location: LocationWithRegion): void {
+    const currentId = this.expandedLocationId();
+    if (currentId === location.id) {
+      this.expandedLocationId.set(null);
+      return;
+    }
+
+    this.expandedLocationId.set(location.id);
+
+    if (!this.locationAreas()[location.id]) {
+      this.loadLocationAreas(location);
+    }
+  }
+
+  private loadLocationAreas(location: LocationWithRegion): void {
+    this.loadingArea.set(true);
+    this.dataService.getLocationDetail(location.id).pipe(
+      switchMap((detail: LocationDetail) => {
+        if (!detail.areas || detail.areas.length === 0) {
+          this.locationAreas.update((areas) => ({ ...areas, [location.id]: [] }));
+          this.loadingArea.set(false);
+          return of([]);
+        }
+
+        const areaRequests = detail.areas.map((area: PokemonSummary) => {
+          const areaId = parseInt(area.url.split('/').filter(Boolean).pop() ?? '0', 10);
+          return this.dataService.getLocationAreaDetail(areaId).pipe(
+            map((areaDetail: LocationAreaDetail) => this.processAreaDetail(areaDetail)),
+            catchError(() => of({ areaName: area.name, pokemon: [] })),
+          );
+        });
+
+        return forkJoin(areaRequests);
+      }),
+      catchError(() => {
+        this.loadingArea.set(false);
+        return of([]);
+      }),
+    ).subscribe((areas: LocationAreaPokemon[]) => {
+      this.locationAreas.update((existing) => ({ ...existing, [location.id]: areas }));
+      this.loadingArea.set(false);
+    });
+  }
+
+  private processAreaDetail(areaDetail: LocationAreaDetail): LocationAreaPokemon {
+    const pokemonMap = new Map<string, { id: number; maxChance: number; methods: Set<string> }>();
+
+    areaDetail.pokemon_encounters.forEach((encounter) => {
+      const name = encounter.pokemon.name;
+      const urlParts = encounter.pokemon.url.split('/').filter(Boolean);
+      const id = parseInt(urlParts[urlParts.length - 1], 10);
+
+      if (!pokemonMap.has(name)) {
+        pokemonMap.set(name, { id, maxChance: 0, methods: new Set() });
+      }
+
+      const entry = pokemonMap.get(name);
+      if (entry) {
+        encounter.version_details.forEach((version) => {
+          if (version.max_chance > entry.maxChance) {
+            entry.maxChance = version.max_chance;
+          }
+          version.encounter_details.forEach((detail) => {
+            entry.methods.add(detail.method.name);
+          });
+        });
+      }
+    });
+
+    const pokemon = Array.from(pokemonMap.entries()).map(([name, data]) => ({
+      name,
+      id: data.id,
+      spriteUrl: this.getSpriteUrl(data.id),
+      maxChance: data.maxChance,
+      methods: Array.from(data.methods),
+    }));
+
+    pokemon.sort((a, b) => a.id - b.id);
+
+    return {
+      areaName: areaDetail.name,
+      pokemon,
+    };
+  }
+
+  private getSpriteUrl(id: number): string {
+    return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`;
+  }
+
+  formatMethodName(method: string): string {
+    return method.replace('-', ' ');
+  }
+
+  onSpriteError(event: Event, id: number): void {
+    const target = event.target as HTMLImageElement;
+    if (target) {
+      target.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`;
+    }
+  }
+}

--- a/src/app/natures-stats/natures-stats.component.html
+++ b/src/app/natures-stats/natures-stats.component.html
@@ -1,0 +1,133 @@
+<div class="natures-stats-container">
+  <ds-page-header
+    title="Natures & Stats"
+    subtitle="Understand how natures affect Pokémon stats"
+  ></ds-page-header>
+
+  @if (loading()) {
+    <div class="loading-container">
+      <ds-pokeball-spinner [size]="60"></ds-pokeball-spinner>
+    </div>
+  } @else if (error()) {
+    <ds-empty-state
+      [message]="error()!"
+      icon="error"
+    ></ds-empty-state>
+  } @else {
+    <mat-tab-group [(selectedIndex)]="activeTab" class="tabs-container">
+      <mat-tab label="Natures">
+        <div class="tab-content">
+          <div class="natures-grid">
+            @for (nature of natures(); track nature.name) {
+              <mat-card class="nature-card">
+                <mat-card-header>
+                  <mat-card-title class="nature-name">{{ nature.displayName }}</mat-card-title>
+                </mat-card-header>
+                <mat-card-content>
+                  @if (nature.isNeutral) {
+                    <div class="stat-row neutral">
+                      <span class="stat-label">Stats</span>
+                      <span class="stat-value">—</span>
+                    </div>
+                  } @else {
+                    <div class="stat-row increased">
+                      <span class="stat-label">Increased</span>
+                      <span class="stat-value" [style.color]="getStatColor(nature.increasedStat)">
+                        +{{ nature.increasedStat }}
+                      </span>
+                    </div>
+                    <div class="stat-row decreased">
+                      <span class="stat-label">Decreased</span>
+                      <span class="stat-value" [style.color]="getStatColor(nature.decreasedStat)">
+                        −{{ nature.decreasedStat }}
+                      </span>
+                    </div>
+                  }
+                  <div class="flavor-section">
+                    <div class="flavor-row">
+                      <span class="flavor-label">Likes</span>
+                      <span class="flavor-value">{{ nature.likedFlavor || '—' }}</span>
+                    </div>
+                    <div class="flavor-row">
+                      <span class="flavor-label">Dislikes</span>
+                      <span class="flavor-value">{{ nature.dislikedFlavor || '—' }}</span>
+                    </div>
+                  </div>
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+        </div>
+      </mat-tab>
+
+      <mat-tab label="Growth Rates">
+        <div class="tab-content">
+          <div class="growth-rates-grid">
+            @for (rate of growthRates(); track rate.name) {
+              <mat-card class="growth-rate-card" [class.expanded]="selectedGrowthRate() === rate">
+                <mat-card-header>
+                  <mat-card-title class="growth-rate-name">{{ rate.displayName }}</mat-card-title>
+                </mat-card-header>
+                <mat-card-content>
+                  <div class="formula">
+                    <code>{{ rate.formula }}</code>
+                  </div>
+                  <div class="xp-curve">
+                    <h4>XP Curve</h4>
+                    <div class="xp-bars">
+                      @for (level of rate.levels; track level.level) {
+                        @if (level.level % 10 === 0 || level.level === 1 || level.level === 50 || level.level === 100) {
+                          <div class="xp-bar-item">
+                            <div class="xp-bar-label">Lv.{{ level.level }}</div>
+                            <div class="xp-bar-container">
+                              <div
+                                class="xp-bar-fill"
+                                [style.width.%]="(level.experience / getMaxXP(rate)) * 100"
+                              ></div>
+                            </div>
+                            <div class="xp-bar-value">{{ level.experience | number }}</div>
+                          </div>
+                        }
+                      }
+                    </div>
+                  </div>
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+        </div>
+      </mat-tab>
+
+      <mat-tab label="Characteristics">
+        <div class="tab-content">
+          <div class="characteristics-intro">
+            <p>
+              Characteristics are short descriptions that indicate which of a Pokémon's stats is its highest IV (Individual Value).
+              Each characteristic corresponds to the stat with the highest IV, helping trainers identify their Pokémon's potential.
+            </p>
+          </div>
+          <div class="characteristics-grid">
+            @for (entry of getCharacteristicGrouped() | keyvalue; track entry.key) {
+              <mat-card class="characteristic-card">
+                <mat-card-header>
+                  <mat-card-title class="characteristic-stat" [style.color]="getStatColor(entry.key)">
+                    {{ entry.key }}
+                  </mat-card-title>
+                </mat-card-header>
+                <mat-card-content>
+                  <ul class="characteristic-list">
+                    @for (char of entry.value; track char.id) {
+                      @for (desc of char.descriptions; track desc) {
+                        <li>{{ desc }}</li>
+                      }
+                    }
+                  </ul>
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
+  }
+</div>

--- a/src/app/natures-stats/natures-stats.component.scss
+++ b/src/app/natures-stats/natures-stats.component.scss
@@ -1,0 +1,271 @@
+.natures-stats-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.tabs-container {
+  margin-top: 1rem;
+}
+
+.tab-content {
+  padding: 1.5rem 0.5rem;
+}
+
+.natures-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.nature-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-card-hover);
+  }
+
+  .mat-mdc-card-header {
+    padding: 1rem 1rem 0.5rem;
+  }
+
+  .mat-mdc-card-content {
+    padding: 0 1rem 1rem;
+  }
+}
+
+.nature-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.stat-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.neutral .stat-value {
+  color: var(--text-secondary);
+}
+
+.flavor-section {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-default);
+}
+
+.flavor-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.flavor-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.flavor-value {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.growth-rates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.growth-rate-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-card-hover);
+  }
+
+  .mat-mdc-card-header {
+    padding: 1rem 1rem 0.5rem;
+  }
+
+  .mat-mdc-card-content {
+    padding: 0 1rem 1rem;
+  }
+}
+
+.growth-rate-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.formula {
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.8rem;
+    color: #8b5cf6;
+    white-space: pre-line;
+    line-height: 1.5;
+  }
+}
+
+.xp-curve {
+  h4 {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 0.75rem;
+  }
+}
+
+.xp-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.xp-bar-item {
+  display: grid;
+  grid-template-columns: 50px 1fr 80px;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.xp-bar-label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.xp-bar-container {
+  height: 8px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.xp-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #8b5cf6, #9c47d8);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.xp-bar-value {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.characteristics-intro {
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+}
+
+.characteristics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.characteristic-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+
+  .mat-mdc-card-header {
+    padding: 1rem 1rem 0.5rem;
+  }
+
+  .mat-mdc-card-content {
+    padding: 0 1rem 1rem;
+  }
+}
+
+.characteristic-stat {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.characteristic-list {
+  margin: 0;
+  padding-left: 1.25rem;
+
+  li {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin-bottom: 0.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .natures-stats-container {
+    padding: 0.75rem;
+  }
+
+  .natures-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .growth-rates-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .characteristics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .xp-bar-item {
+    grid-template-columns: 45px 1fr 70px;
+  }
+}

--- a/src/app/natures-stats/natures-stats.component.ts
+++ b/src/app/natures-stats/natures-stats.component.ts
@@ -1,0 +1,240 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatCardModule } from '@angular/material/card';
+import { DataServiceService } from '../services/data-service.service';
+import { NatureDetail, PokemonSummary, GrowthRateDetail, CharacteristicDetail } from '../shared/pokemon-api.interfaces';
+import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
+import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
+import { EmptyStateComponent } from '../shared/components/empty-state/empty-state.component';
+import { catchError, of, forkJoin } from 'rxjs';
+
+const STAT_NAMES: Record<string, string> = {
+  'hp': 'HP',
+  'attack': 'Attack',
+  'defense': 'Defense',
+  'special-attack': 'Sp. Atk',
+  'special-defense': 'Sp. Def',
+  'speed': 'Speed'
+};
+
+const FLAVOR_NAMES: Record<string, string> = {
+  'spicy': 'Spicy',
+  'dry': 'Dry',
+  'sweet': 'Sweet',
+  'bitter': 'Bitter',
+  'sour': 'Sour'
+};
+
+const GROWTH_RATE_NAMES: Record<string, string> = {
+  'erratic': 'Erratic',
+  'fast': 'Fast',
+  'medium-fast': 'Medium Fast',
+  'medium-slow': 'Medium Slow',
+  'slow': 'Slow',
+  'fluctuating': 'Fluctuating'
+};
+
+const GROWTH_RATE_FORMULAS: Record<string, string> = {
+  'erratic': 'If L < 50: (L³ × (100 − L)) / 50\nIf 50 ≤ L ≤ 68: (L³ × (150 − L)) / 100\nIf 68 < L ≤ 98: (L³ × ⌊(1911 − 10×L) / 3⌋) / 500\nIf L > 98: (L³ × (160 − L)) / 100',
+  'fast': '(4 × L³) / 5',
+  'medium-fast': 'L³',
+  'medium-slow': '(6 × L³) / 5 − 15 × L² + 100 × L − 140',
+  'slow': '(5 × L³) / 4',
+  'fluctuating': 'If L < 15: (L³ × (⌊(L + 1) / 3⌋ + 24)) / 50\nIf 15 ≤ L ≤ 35: (L³ × (L + 14)) / 50\nIf L > 35: (L³ × (⌊L / 2⌋ + 32)) / 50'
+};
+
+interface NatureDisplay {
+  name: string;
+  displayName: string;
+  increasedStat: string;
+  decreasedStat: string;
+  likedFlavor: string;
+  dislikedFlavor: string;
+  isNeutral: boolean;
+}
+
+interface GrowthRateDisplay {
+  name: string;
+  displayName: string;
+  formula: string;
+  levels: { level: number; experience: number }[];
+}
+
+interface CharacteristicDisplay {
+  id: number;
+  stat: string;
+  descriptions: string[];
+}
+
+@Component({
+  selector: 'app-natures-stats',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    MatCardModule,
+    PokeballSpinnerComponent,
+    PageHeaderComponent,
+    EmptyStateComponent
+  ],
+  templateUrl: './natures-stats.component.html',
+  styleUrl: './natures-stats.component.scss'
+})
+export class NaturesStatsComponent implements OnInit {
+  private dataService = inject(DataServiceService);
+
+  natures = signal<NatureDisplay[]>([]);
+  growthRates = signal<GrowthRateDisplay[]>([]);
+  characteristics = signal<CharacteristicDisplay[]>([]);
+  loading = signal(true);
+  error = signal<string | null>(null);
+  activeTab = signal(0);
+
+  selectedGrowthRate = signal<GrowthRateDisplay | null>(null);
+
+  ngOnInit(): void {
+    this.loadNatures();
+    this.loadGrowthRates();
+    this.loadCharacteristics();
+  }
+
+  loadNatures(): void {
+    this.dataService.getAllNatures().pipe(
+      catchError(() => {
+        this.error.set('Failed to load natures');
+        return of([]);
+      })
+    ).subscribe((summaries: PokemonSummary[]) => {
+      if (summaries.length === 0) {
+        this.loading.set(false);
+        return;
+      }
+
+      const requests = summaries.map((s: PokemonSummary) => {
+        const id = parseInt(s.url.split('/').filter(Boolean).pop() ?? '0', 10);
+        return this.dataService.getNatureDetail(id).pipe(
+          catchError(() => of(null))
+        );
+      });
+
+      forkJoin(requests).subscribe((details: (NatureDetail | null)[]) => {
+        const validDetails = details.filter((d): d is NatureDetail => d !== null);
+        const displayNatures: NatureDisplay[] = validDetails.map((d: NatureDetail) => {
+          const increasedStat = d.increased_stat ? d.increased_stat.name : '';
+          const decreasedStat = d.decreased_stat ? d.decreased_stat.name : '';
+          const likedFlavor = d.likes_flavor ? d.likes_flavor.name : '';
+          const dislikedFlavor = d.hates_flavor ? d.hates_flavor.name : '';
+
+          return {
+            name: d.name,
+            displayName: this.capitalizeName(d.name),
+            increasedStat: STAT_NAMES[increasedStat] || '',
+            decreasedStat: STAT_NAMES[decreasedStat] || '',
+            likedFlavor: FLAVOR_NAMES[likedFlavor] || '',
+            dislikedFlavor: FLAVOR_NAMES[dislikedFlavor] || '',
+            isNeutral: !increasedStat && !decreasedStat
+          };
+        });
+
+        this.natures.set(displayNatures);
+        this.loading.set(false);
+      });
+    });
+  }
+
+  loadGrowthRates(): void {
+    const ids = [1, 2, 3, 4, 5, 6];
+    const requests = ids.map((id: number) =>
+      this.dataService.getGrowthRateDetail(id).pipe(
+        catchError(() => of(null))
+      )
+    );
+
+    forkJoin(requests).subscribe((details: (GrowthRateDetail | null)[]) => {
+      const validDetails = details.filter((d): d is GrowthRateDetail => d !== null);
+      const displayRates: GrowthRateDisplay[] = validDetails.map((d: GrowthRateDetail) => ({
+        name: d.name,
+        displayName: GROWTH_RATE_NAMES[d.name] || this.capitalizeName(d.name),
+        formula: GROWTH_RATE_FORMULAS[d.name] || d.formula,
+        levels: d.levels
+      }));
+
+      this.growthRates.set(displayRates);
+    });
+  }
+
+  loadCharacteristics(): void {
+    const ids = Array.from({ length: 30 }, (_, i) => i + 1);
+    const requests = ids.map((id: number) =>
+      this.dataService.getCharacteristicDetail(id).pipe(
+        catchError(() => of(null))
+      )
+    );
+
+    forkJoin(requests).subscribe((details: (CharacteristicDetail | null)[]) => {
+      const validDetails = details.filter((d): d is CharacteristicDetail => d !== null);
+      const displayChars: CharacteristicDisplay[] = validDetails.map((d: CharacteristicDetail) => ({
+        id: d.id,
+        stat: STAT_NAMES[d.highest_stat.name] || d.highest_stat.name,
+        descriptions: d.descriptions
+          .filter((desc) => desc.language.name === 'en')
+          .map((desc) => desc.description)
+      }));
+
+      this.characteristics.set(displayChars);
+    });
+  }
+
+  capitalizeName(name: string): string {
+    return name.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+  }
+
+  getStatColor(stat: string): string {
+    const colors: Record<string, string> = {
+      'HP': '#ff5959',
+      'Attack': '#f5ac78',
+      'Defense': '#fae078',
+      'Sp. Atk': '#9db7f5',
+      'Sp. Def': '#a7db8d',
+      'Speed': '#fa92b2'
+    };
+    return colors[stat] || '#888';
+  }
+
+  selectGrowthRate(rate: GrowthRateDisplay): void {
+    if (this.selectedGrowthRate() === rate) {
+      this.selectedGrowthRate.set(null);
+    } else {
+      this.selectedGrowthRate.set(rate);
+    }
+  }
+
+  getXPForLevel(rate: GrowthRateDisplay, level: number): number {
+    const found = rate.levels.find(l => l.level === level);
+    return found ? found.experience : 0;
+  }
+
+  getMaxXP(rate: GrowthRateDisplay): number {
+    if (rate.levels.length === 0) return 0;
+    return Math.max(...rate.levels.map(l => l.experience));
+  }
+
+  getCharacteristicGrouped(): Map<string, CharacteristicDisplay[]> {
+    const grouped = new Map<string, CharacteristicDisplay[]>();
+    this.characteristics().forEach((c: CharacteristicDisplay) => {
+      if (!grouped.has(c.stat)) {
+        grouped.set(c.stat, []);
+      }
+      const items = grouped.get(c.stat);
+      if (items) items.push(c);
+    });
+    return grouped;
+  }
+}

--- a/src/app/photo-pokemon/photo-pokemon.component.html
+++ b/src/app/photo-pokemon/photo-pokemon.component.html
@@ -38,12 +38,13 @@
       <div class="keyboard-hints" aria-hidden="true">
         <span class="hint"><kbd>←</kbd><kbd>→</kbd> Browse</span>
         <span class="hint"><kbd>S</kbd> Shiny</span>
+        <span class="hint"><kbd>?</kbd> All</span>
       </div>
 
-      <!-- Main Content -->
-      <div class="main-content">
-        <!-- Left: Pokemon Image -->
-        <div class="image-section">
+      <!-- Main Grid Layout -->
+      <div class="pokemon-grid">
+        <!-- Row 1: Sprite (top-left) + Header Info (top-right) -->
+        <div class="grid-sprite">
           <div class="pokemon-id-badge">#{{ pokemon()!.id | number:'3.0-0' }}</div>
           <div class="image-wrapper">
             <img
@@ -105,18 +106,14 @@
           </div>
         </div>
 
-        <!-- Right: Pokemon Info -->
-        <div class="info-section">
+        <!-- Header: Name, Types, Physical Info -->
+        <div class="grid-header">
           <h1 class="pokemon-name">{{ capitalize(pokemon()!.name) }}</h1>
-
-          <!-- Types -->
           <div class="types-container" aria-label="Pokémon types">
             @for (type of pokemon()!.types; track $index) {
               <ds-type-badge [type]="type.type.name" variant="ghost"></ds-type-badge>
             }
           </div>
-
-          <!-- Physical Info -->
           <div class="physical-info">
             <div class="info-item">
               <span class="info-label">Height</span>
@@ -127,8 +124,33 @@
               <span class="info-value">{{ (pokemon()!.weight / 10).toFixed(1) }} kg</span>
             </div>
           </div>
+        </div>
 
-          <!-- Abilities -->
+        <!-- Row 2: Stats Bars (left) + Radar Chart (right) -->
+        <div class="grid-stats">
+          <div class="stats-block" aria-describedby="stats-description">
+            <h2 class="block-title">Base Stats</h2>
+            <span id="stats-description" class="sr-only">Base statistics for {{ capitalize(pokemon()!.name) }}</span>
+            <div class="stats-container">
+              @for (stat of pokemon()!.stats; track stat.stat.name) {
+                <ds-stat-bar [label]="stat.stat.name" [value]="stat.base_stat"></ds-stat-bar>
+              }
+            </div>
+            <div class="total-stats">
+              <span class="total-label">Total</span>
+              <span class="total-value">{{ getTotalStats() }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid-radar">
+          @if (pokemon()) {
+            <app-stats-radar [stats]="pokemon()!.stats.map(s => ({ name: s.stat.name, value: s.base_stat }))"></app-stats-radar>
+          }
+        </div>
+
+        <!-- Row 3: Abilities (left) + Moves (right) -->
+        <div class="grid-abilities">
           <div class="info-block">
             <h2 class="block-title">Abilities</h2>
             <div class="abilities-list">
@@ -142,19 +164,9 @@
               }
             </div>
           </div>
+        </div>
 
-          <!-- Stats with Progress Bars -->
-          <div class="stats-block" aria-describedby="stats-description">
-            <h2 class="block-title">Base Stats</h2>
-            <span id="stats-description" class="sr-only">Base statistics for {{ capitalize(pokemon()!.name) }}</span>
-            <div class="stats-container">
-              @for (stat of pokemon()!.stats; track stat.stat.name) {
-                <ds-stat-bar [label]="stat.stat.name" [value]="stat.base_stat"></ds-stat-bar>
-              }
-            </div>
-          </div>
-
-          <!-- Moves -->
+        <div class="grid-moves">
           <div class="info-block">
             <h2 class="block-title">Moves</h2>
             <div class="moves-list">
@@ -163,28 +175,37 @@
               }
             </div>
           </div>
+        </div>
 
-          <!-- Evolution Chain -->
-          @if (species()) {
-            <app-evolution-chain
-              [pokemonId]="pokemon()!.id"
-              [pokemonSpecies]="species()!"
-            ></app-evolution-chain>
+        <!-- Row 4: Sprite Gallery (full width) -->
+        <div class="grid-gallery">
+          @if (pokemonId()) {
+            <app-sprite-gallery [pokemonId]="pokemonId()!" [isShiny]="isShiny()"></app-sprite-gallery>
           }
+        </div>
 
-          <!-- Bottom Navigation -->
-          <div class="bottom-nav">
-            <button mat-flat-button class="nav-action-btn team-btn" (click)="navigateToTeam()">
-              <mat-icon>group</mat-icon>
-              My Team
-            </button>
-            <button mat-stroked-button class="nav-action-btn pokedex-btn" (click)="navigateToCatalog()">
-              <mat-icon>book</mat-icon>
-              Pokédex
-            </button>
-          </div>
+        <!-- Row 5: Species Detail (full width) -->
+        <div class="grid-species">
+          @if (pokemonId()) {
+            <app-species-detail [pokemonId]="pokemonId()!" [speciesData]="species()"></app-species-detail>
+          }
+        </div>
+
+        <!-- Bottom Navigation -->
+        <div class="grid-bottom-nav">
+          <button mat-flat-button class="nav-action-btn team-btn" (click)="navigateToTeam()">
+            <mat-icon>group</mat-icon>
+            My Team
+          </button>
+          <button mat-stroked-button class="nav-action-btn pokedex-btn" (click)="navigateToCatalog()">
+            <mat-icon>book</mat-icon>
+            Pokédex
+          </button>
         </div>
       </div>
     </div>
   }
+
+  <!-- Shortcuts Modal -->
+  <app-shortcuts-modal></app-shortcuts-modal>
 </div>

--- a/src/app/photo-pokemon/photo-pokemon.component.scss
+++ b/src/app/photo-pokemon/photo-pokemon.component.scss
@@ -1,8 +1,8 @@
 .pokemon-page {
   min-height: 100vh;
-  background: #0f0f1a;
-  color: #fff;
-  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 
 .loading-container {
@@ -22,7 +22,7 @@
   justify-content: center;
   min-height: 100vh;
   gap: 1rem;
-  color: #ff6b6b;
+  color: var(--color-danger);
 }
 
 .pokemon-container {
@@ -42,24 +42,24 @@
     z-index: 0;
   }
 
-  &.bg-normal { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%); }
-  &.bg-fire { background: linear-gradient(135deg, #1a1a2e 0%, #2d1b1b 50%, #4a1942 100%); }
-  &.bg-water { background: linear-gradient(135deg, #1a1a2e 0%, #1b2d3d 50%, #1b3a4a 100%); }
-  &.bg-grass { background: linear-gradient(135deg, #1a1a2e 0%, #1b2d1b 50%, #1b4a2a 100%); }
-  &.bg-electric { background: linear-gradient(135deg, #1a1a2e 0%, #2d2d1b 50%, #3a3a1b 100%); }
-  &.bg-ice { background: linear-gradient(135deg, #1a1a2e 0%, #1b2d3d 50%, #1b3a3a 100%); }
-  &.bg-fighting { background: linear-gradient(135deg, #1a1a2e 0%, #2d1b1b 50%, #3a1b1b 100%); }
-  &.bg-poison { background: linear-gradient(135deg, #1a1a2e 0%, #2d1b2d 50%, #3a1b3a 100%); }
-  &.bg-ground { background: linear-gradient(135deg, #1a1a2e 0%, #2d2d1b 50%, #3a2d1b 100%); }
-  &.bg-flying { background: linear-gradient(135deg, #1a1a2e 0%, #1b1b2d 50%, #1b2d3a 100%); }
-  &.bg-psychic { background: linear-gradient(135deg, #1a1a2e 0%, #2d1b2d 50%, #3a1b2d 100%); }
-  &.bg-bug { background: linear-gradient(135deg, #1a1a2e 0%, #1b2d1b 50%, #2d3a1b 100%); }
-  &.bg-rock { background: linear-gradient(135deg, #1a1a2e 0%, #2d2d2d 50%, #3a3a3a 100%); }
-  &.bg-ghost { background: linear-gradient(135deg, #1a1a2e 0%, #1b1b2d 50%, #2d1b3a 100%); }
-  &.bg-dragon { background: linear-gradient(135deg, #1a1a2e 0%, #1b1b2d 50%, #1b2d3a 100%); }
-  &.bg-dark { background: linear-gradient(135deg, #0a0a14 0%, #141420 50%, #1a1a28 100%); }
-  &.bg-steel { background: linear-gradient(135deg, #1a1a2e 0%, #2d2d2d 50%, #3a3a3a 100%); }
-  &.bg-fairy { background: linear-gradient(135deg, #1a1a2e 0%, #2d1b2d 50%, #3a1b3a 100%); }
+  &.bg-normal { background: var(--gradient-hero); }
+  &.bg-fire { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d1b1b 50%, #4a1942 100%); }
+  &.bg-water { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b2d3d 50%, #1b3a4a 100%); }
+  &.bg-grass { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b2d1b 50%, #1b4a2a 100%); }
+  &.bg-electric { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d2d1b 50%, #3a3a1b 100%); }
+  &.bg-ice { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b2d3d 50%, #1b3a3a 100%); }
+  &.bg-fighting { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d1b1b 50%, #3a1b1b 100%); }
+  &.bg-poison { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d1b2d 50%, #3a1b3a 100%); }
+  &.bg-ground { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d2d1b 50%, #3a2d1b 100%); }
+  &.bg-flying { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b1b2d 50%, #1b2d3a 100%); }
+  &.bg-psychic { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d1b2d 50%, #3a1b2d 100%); }
+  &.bg-bug { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b2d1b 50%, #2d3a1b 100%); }
+  &.bg-rock { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d2d2d 50%, #3a3a3a 100%); }
+  &.bg-ghost { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b1b2d 50%, #2d1b3a 100%); }
+  &.bg-dragon { background: linear-gradient(135deg, var(--bg-primary) 0%, #1b1b2d 50%, #1b2d3a 100%); }
+  &.bg-dark { background: linear-gradient(135deg, var(--bg-primary) 0%, #141420 50%, #1a1a28 100%); }
+  &.bg-steel { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d2d2d 50%, #3a3a3a 100%); }
+  &.bg-fairy { background: linear-gradient(135deg, var(--bg-primary) 0%, #2d1b2d 50%, #3a1b3a 100%); }
 }
 
 .nav-arrows {
@@ -79,7 +79,7 @@
     background: rgba(255, 255, 255, 0.1);
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.15);
-    color: #fff;
+    color: var(--text-inverse);
     width: 48px;
     height: 48px;
     border-radius: 50%;
@@ -107,7 +107,7 @@
 .back-btn {
   position: relative;
   z-index: 10;
-  color: #fff;
+  color: var(--text-inverse);
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -162,30 +162,20 @@
   }
 }
 
-.main-content {
+.pokemon-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2rem;
+  grid-template-rows: auto auto auto auto auto auto auto;
+  gap: 1.5rem;
   max-width: 1200px;
   margin: 0 auto;
   position: relative;
   z-index: 1;
 }
 
-@media (max-width: 900px) {
-  .main-content {
-    grid-template-columns: 1fr;
-  }
-  .nav-arrows {
-    position: static;
-    transform: none;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
-  }
-}
-
-.image-section {
+.grid-sprite {
+  grid-column: 1;
+  grid-row: 1 / 3;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -194,7 +184,7 @@
 
   .pokemon-id-badge {
     position: absolute;
-    top: 0;
+    top: -10px;
     left: 50%;
     transform: translateX(-50%);
     font-size: 3rem;
@@ -206,8 +196,8 @@
 
   .image-wrapper {
     position: relative;
-    width: 320px;
-    height: 320px;
+    width: 280px;
+    height: 280px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -242,8 +232,8 @@
     }
 
     .pokemon-main-img {
-      width: 280px;
-      height: 280px;
+      width: 260px;
+      height: 260px;
       object-fit: contain;
       position: relative;
       z-index: 1;
@@ -267,7 +257,7 @@
         background: rgba(255, 255, 255, 0.15) !important;
         backdrop-filter: blur(10px);
         border: 1px solid rgba(255, 255, 255, 0.2);
-        color: #fff !important;
+        color: var(--text-inverse) !important;
         transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
 
         mat-icon {
@@ -328,10 +318,12 @@
   50% { transform: translateY(-10px); }
 }
 
-.info-section {
+.grid-header {
+  grid-column: 2;
+  grid-row: 1;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 0.75rem;
 
   .pokemon-name {
     font-size: 2.5rem;
@@ -363,7 +355,7 @@
 
     .info-label {
       font-size: 0.75rem;
-      color: #888;
+      color: var(--text-tertiary);
       text-transform: uppercase;
       letter-spacing: 1px;
     }
@@ -371,85 +363,44 @@
     .info-value {
       font-size: 1.1rem;
       font-weight: 600;
-      color: #fff;
+      color: var(--text-primary);
     }
   }
 }
 
-.info-block {
-  .block-title {
-    font-size: 0.8rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: #888;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .abilities-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-
-    .ability-tag {
-      padding: 0.35rem 0.75rem;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 8px;
-      font-size: 0.85rem;
-      color: #ddd;
-      text-transform: capitalize;
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
-
-      .hidden-badge {
-        font-size: 0.65rem;
-        padding: 0.15rem 0.4rem;
-        background: rgba(255, 107, 107, 0.2);
-        color: #ff6b6b;
-        border-radius: 4px;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-      }
-    }
-  }
-
-  .moves-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-
-    .move-tag {
-      padding: 0.3rem 0.6rem;
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 6px;
-      font-size: 0.75rem;
-      color: #aaa;
-      text-transform: capitalize;
-    }
-  }
+.grid-stats {
+  grid-column: 2;
+  grid-row: 2;
 }
 
-.stats-block {
-  .block-title {
-    font-size: 0.8rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: #888;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .stats-container {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-  }
+.grid-radar {
+  grid-column: 1 / 3;
+  grid-row: 3;
 }
 
-.bottom-nav {
+.grid-abilities {
+  grid-column: 1;
+  grid-row: 4;
+}
+
+.grid-moves {
+  grid-column: 2;
+  grid-row: 4;
+}
+
+.grid-gallery {
+  grid-column: 1 / 3;
+  grid-row: 5;
+}
+
+.grid-species {
+  grid-column: 1 / 3;
+  grid-row: 6;
+}
+
+.grid-bottom-nav {
+  grid-column: 1 / 3;
+  grid-row: 7;
   display: flex;
   gap: 0.75rem;
   margin-top: 0.5rem;
@@ -484,5 +435,163 @@
         transform: translateY(-2px);
       }
     }
+  }
+}
+
+.info-block {
+  .block-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--text-tertiary);
+    margin: 0 0 0.75rem 0;
+  }
+
+  .abilities-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+
+    .ability-tag {
+      padding: 0.35rem 0.75rem;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      text-transform: capitalize;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+
+      .hidden-badge {
+        font-size: 0.65rem;
+        padding: 0.15rem 0.4rem;
+        background: rgba(255, 107, 107, 0.2);
+        color: #ff6b6b;
+        border-radius: 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+    }
+  }
+
+  .moves-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+
+    .move-tag {
+      padding: 0.3rem 0.6rem;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 6px;
+      font-size: 0.75rem;
+      color: var(--text-tertiary);
+      text-transform: capitalize;
+    }
+  }
+}
+
+.stats-block {
+  .block-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--text-tertiary);
+    margin: 0 0 0.75rem 0;
+  }
+
+  .stats-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .total-stats {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+
+    .total-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: var(--text-tertiary);
+    }
+
+    .total-value {
+      font-size: 1.1rem;
+      font-weight: 800;
+      color: var(--text-primary);
+      font-variant-numeric: tabular-nums;
+    }
+  }
+}
+
+@media (max-width: 900px) {
+  .pokemon-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+
+  .grid-sprite {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .grid-header {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .grid-stats {
+    grid-column: 1;
+    grid-row: 3;
+  }
+
+  .grid-radar {
+    grid-column: 1;
+    grid-row: 4;
+  }
+
+  .grid-abilities {
+    grid-column: 1;
+    grid-row: 5;
+  }
+
+  .grid-moves {
+    grid-column: 1;
+    grid-row: 6;
+  }
+
+  .grid-gallery {
+    grid-column: 1;
+    grid-row: 7;
+  }
+
+  .grid-species {
+    grid-column: 1;
+    grid-row: 8;
+  }
+
+  .grid-bottom-nav {
+    grid-column: 1;
+    grid-row: 9;
+  }
+
+  .nav-arrows {
+    position: static;
+    transform: none;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
   }
 }

--- a/src/app/photo-pokemon/photo-pokemon.component.ts
+++ b/src/app/photo-pokemon/photo-pokemon.component.ts
@@ -1,25 +1,29 @@
-import { Component, OnInit, OnDestroy, signal, HostListener, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, signal, HostListener, inject, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DataServiceService } from '../services/data-service.service';
 import { FavoritesService } from '../services/favorites.service';
 import { TeamService } from '../services/team.service';
+import { ProgressService } from '../services/progress.service';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { PokemonDetail, PokemonSpecies } from '../shared/pokemon-api.interfaces';
+import { PokemonDetail, PokemonSpeciesDetail } from '../shared/pokemon-api.interfaces';
 import { Pokemon } from '../shared/pokemon';
 import { TypeBadgeComponent } from '../shared/components/type-badge/type-badge.component';
 import { StatBarComponent } from '../shared/components/stat-bar/stat-bar.component';
 import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
-import { EvolutionChainComponent } from '../shared/components/evolution-chain/evolution-chain.component';
+import { SpeciesDetailComponent } from '../shared/components/species-detail/species-detail.component';
+import { SpriteGalleryComponent } from '../shared/components/sprite-gallery/sprite-gallery.component';
+import { ShortcutsModalComponent } from '../shared/components/shortcuts-modal/shortcuts-modal.component';
+import { StatsRadarComponent } from '../shared/components/stats-radar/stats-radar.component';
 import { capitalize, getStatShortName } from '../shared/utils/pokemon.utils';
 import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-photo-pokemon',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule, TypeBadgeComponent, StatBarComponent, PokeballSpinnerComponent, EvolutionChainComponent],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule, TypeBadgeComponent, StatBarComponent, PokeballSpinnerComponent, SpeciesDetailComponent, SpriteGalleryComponent, ShortcutsModalComponent, StatsRadarComponent],
   templateUrl: './photo-pokemon.component.html',
   styleUrls: ['./photo-pokemon.component.scss']
 })
@@ -27,12 +31,15 @@ export class PhotoPokemonComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
   private favoritesService = inject(FavoritesService);
   private teamService = inject(TeamService);
+  private progressService = inject(ProgressService);
+
+  @ViewChild(ShortcutsModalComponent) shortcutsModal!: ShortcutsModalComponent;
 
   pokemonId = signal<number | null>(null);
   pokemon = signal<PokemonDetail | null>(null);
   loading = signal(true);
   error = signal<string | null>(null);
-  species = signal<PokemonSpecies | null>(null);
+  species = signal<PokemonSpeciesDetail | null>(null);
   hasPrev = signal(true);
   hasNext = signal(true);
   prevId = signal(0);
@@ -79,6 +86,7 @@ export class PhotoPokemonComponent implements OnInit, OnDestroy {
     this.error.set(null);
     this.isShiny.set(false);
     this.species.set(null);
+    this.progressService.markViewed(id);
 
     this.dataService.getPokemonDetail(id).pipe(
       takeUntil(this.destroy$)
@@ -102,10 +110,10 @@ export class PhotoPokemonComponent implements OnInit, OnDestroy {
   }
 
   private loadSpecies(id: number): void {
-    this.dataService.getPokemonSpecies(id).pipe(
+    this.dataService.getPokemonSpeciesDetail(id).pipe(
       takeUntil(this.destroy$)
     ).subscribe({
-      next: (speciesData: PokemonSpecies) => {
+      next: (speciesData: PokemonSpeciesDetail) => {
         if (speciesData && speciesData.id) {
           this.species.set(speciesData);
         }
@@ -162,12 +170,35 @@ export class PhotoPokemonComponent implements OnInit, OnDestroy {
           this.toggleShiny();
         }
         break;
+      case 'f':
+      case 'F':
+        if (!event.ctrlKey && !event.metaKey && !(event.target instanceof HTMLInputElement)) {
+          this.toggleFavorite();
+        }
+        break;
+      case 't':
+      case 'T':
+        if (!event.ctrlKey && !event.metaKey && !(event.target instanceof HTMLInputElement)) {
+          this.addToTeam();
+        }
+        break;
+      case '?':
+        if (!(event.target instanceof HTMLInputElement)) {
+          this.shortcutsModal?.open();
+        }
+        break;
       case 'Escape':
         if (event.target instanceof HTMLInputElement) {
           (event.target as HTMLInputElement).blur();
         }
         break;
     }
+  }
+
+  getTotalStats(): number {
+    const p = this.pokemon();
+    if (!p) return 0;
+    return p.stats.reduce((sum, s) => sum + s.base_stat, 0);
   }
 
   capitalize = capitalize;

--- a/src/app/regional-pokedex/regional-pokedex.component.html
+++ b/src/app/regional-pokedex/regional-pokedex.component.html
@@ -3,7 +3,7 @@
     <mat-icon>book</mat-icon>
     <span>
       @if (pokedex()) {
-        {{ pokedex()!.pokemon_entries.length }} Pokémon in {{ pokedex()!.name | titlecase }}
+        {{ filteredEntries().length }} / {{ pokedex()!.pokemon_entries.length }} Pokémon in {{ pokedex()!.name | titlecase }}
       } @else {
         Select a Pokédex
       }
@@ -27,6 +27,19 @@
         </button>
       }
     </div>
+  </div>
+
+  <div class="search-bar-container">
+    <mat-form-field appearance="outline" class="search-field">
+      <mat-label>Search Pokémon by name</mat-label>
+      <input matInput [formControl]="searchControl" placeholder="e.g., pikachu, charizard">
+      <mat-icon matPrefix>search</mat-icon>
+      @if (searchControl.value) {
+        <button matSuffix mat-icon-button aria-label="Clear" (click)="clearSearch()" type="button">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+    </mat-form-field>
   </div>
 </ds-page-header>
 
@@ -53,10 +66,20 @@
     }
   </div>
 
-  @if (pokedex()!.pokemon_entries.length > 0) {
+  <div class="progress-section">
+    <div class="progress-header">
+      <mat-icon>visibility</mat-icon>
+      <span class="progress-text">{{ viewedCount() }} / {{ filteredEntries().length }} viewed</span>
+    </div>
+    <div class="progress-bar-track">
+      <div class="progress-bar-fill" [style.width.%]="(filteredEntries().length > 0) ? (viewedCount() / filteredEntries().length * 100) : 0"></div>
+    </div>
+  </div>
+
+  @if (filteredEntries().length > 0) {
     <div class="pokedex-grid" role="list">
-      @for (entry of pokedex()!.pokemon_entries; track entry.entry_number; let i = $index) {
-        <div role="listitem" [attr.data-pokemon-id]="extractPokemonId(entry.pokemon_species.url)">
+      @for (entry of filteredEntries(); track entry.entry_number; let i = $index) {
+        <div role="listitem" [attr.data-pokemon-id]="extractPokemonId(entry.pokemon_species.url)" [class.viewed]="isViewed(extractPokemonId(entry.pokemon_species.url))">
           <ds-poke-card
             [pokemon]="{
               id: extractPokemonId(entry.pokemon_species.url),
@@ -89,9 +112,9 @@
     </div>
   } @else {
     <ds-empty-state
-      icon="explore"
-      title="No Pokémon in this Pokédex"
-      message="This Pokédex doesn't have any entries yet. Try selecting a different Pokédex!"
+      icon="search_off"
+      [title]="searchTerm() ? 'No Pokémon found' : 'No Pokémon available'"
+      [message]="searchTerm() ? 'Try a different search term.' : 'This Pokédex has no entries.'"
       [compact]="true"
     ></ds-empty-state>
   }

--- a/src/app/regional-pokedex/regional-pokedex.component.scss
+++ b/src/app/regional-pokedex/regional-pokedex.component.scss
@@ -7,7 +7,7 @@
     justify-content: center;
     gap: 8px;
     margin-bottom: 14px;
-    color: var(--text-tertiary, #737373);
+    color: var(--text-tertiary);
     font-size: 0.8em;
     font-weight: 600;
     text-transform: uppercase;
@@ -32,21 +32,21 @@
   border-radius: 20px;
   font-size: 0.8em;
   font-weight: 600;
-  border: 1.5px solid var(--border-subtle, #e4e4e4);
-  background: var(--surface-card, #ffffff);
-  color: var(--text-secondary, #525252);
+  border: 1.5px solid var(--border-subtle);
+  background: var(--surface-card);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 
   &:hover {
     transform: scale(1.05);
-    border-color: var(--brand-primary, #8b5cf6);
+    border-color: var(--brand-primary);
   }
 
   &.active {
-    background: var(--brand-primary, #8b5cf6);
+    background: var(--brand-primary);
     color: #fff;
-    border-color: var(--brand-primary, #8b5cf6);
+    border-color: var(--brand-primary);
     box-shadow: 0 2px 8px rgba(139, 92, 246, 0.3);
   }
 
@@ -62,6 +62,15 @@
   }
 }
 
+.search-bar-container {
+  max-width: 500px;
+  margin: 20px auto 0;
+
+  .search-field {
+    width: 100%;
+  }
+}
+
 .pokedex-info {
   display: flex;
   align-items: center;
@@ -72,7 +81,7 @@
 
   .pokedex-description {
     font-size: 0.9em;
-    color: var(--text-secondary, #525252);
+    color: var(--text-secondary);
     margin: 0;
     font-style: italic;
   }
@@ -86,10 +95,53 @@
     font-size: 0.75em;
     font-weight: 600;
     background: rgba(139, 92, 246, 0.1);
-    color: var(--brand-primary, #8b5cf6);
+    color: var(--brand-primary);
     text-transform: capitalize;
 
     mat-icon { font-size: 14px; width: 14px; height: 14px; }
+  }
+}
+
+.progress-section {
+  padding: 0 24px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+
+  .progress-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      color: var(--brand-primary);
+    }
+
+    .progress-text {
+      font-size: 0.85em;
+      font-weight: 600;
+      color: var(--text-secondary);
+      flex: 1;
+    }
+  }
+
+  .progress-bar-track {
+    width: 100%;
+    height: 6px;
+    background: var(--surface-card);
+    border-radius: 3px;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+
+    .progress-bar-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--brand-primary), var(--brand-secondary));
+      border-radius: 3px;
+      transition: width 300ms ease-out;
+    }
   }
 }
 
@@ -103,12 +155,26 @@
 
   [data-pokemon-id] {
     transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+
+    &.viewed::after {
+      content: '';
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--brand-primary);
+      box-shadow: 0 0 6px rgba(139, 92, 246, 0.5);
+      z-index: 1;
+    }
 
     &.added-to-team {
       transform: scale(0.95);
 
       ds-poke-card {
-        border-color: var(--color-success, #10b981);
+        border-color: var(--color-success);
         box-shadow: 0 0 20px rgba(16, 185, 129, 0.3);
       }
     }
@@ -117,21 +183,21 @@
   .entry-number {
     font-size: 0.7em;
     font-weight: 600;
-    color: var(--text-tertiary, #737373);
+    color: var(--text-tertiary);
   }
 
   .add-team-btn {
-    color: var(--brand-primary, #8b5cf6);
+    color: var(--brand-primary);
     transition: all 150ms;
 
     &:hover {
       transform: scale(1.15);
-      color: var(--brand-primary-dark, #7c3aed);
+      color: var(--brand-primary-dark);
     }
   }
 
   .in-team-icon {
-    color: var(--color-success, #10b981);
+    color: var(--color-success);
     font-size: 20px;
     width: 20px;
     height: 20px;

--- a/src/app/regional-pokedex/regional-pokedex.component.ts
+++ b/src/app/regional-pokedex/regional-pokedex.component.ts
@@ -1,16 +1,22 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { debounceTime } from 'rxjs';
 import { DataServiceService } from '../services/data-service.service';
 import { PokedexDetail } from '../shared/pokemon-api.interfaces';
 import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
 import { EmptyStateComponent } from '../shared/components/empty-state/empty-state.component';
 import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
 import { PokeCardComponent } from '../shared/components/poke-card/poke-card.component';
+import { TypeBadgeComponent } from '../shared/components/type-badge/type-badge.component';
 import { capitalize, getOfficialArtworkUrl } from '../shared/utils/pokemon.utils';
 import { TeamService } from '../services/team.service';
+import { ProgressService } from '../services/progress.service';
 import { Pokemon } from '../shared/pokemon';
 
 interface PokedexOption {
@@ -59,6 +65,9 @@ const POKEDEX_OPTIONS: PokedexOption[] = [
     RouterModule,
     MatButtonModule,
     MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    ReactiveFormsModule,
     PokeballSpinnerComponent,
     EmptyStateComponent,
     PageHeaderComponent,
@@ -70,19 +79,48 @@ const POKEDEX_OPTIONS: PokedexOption[] = [
 export class RegionalPokedexComponent implements OnInit {
   private dataService = inject(DataServiceService);
   private teamService = inject(TeamService);
+  private progressService = inject(ProgressService);
   private router = inject(Router);
 
   pokedexOptions = POKEDEX_OPTIONS;
 
+  searchControl = new FormControl('');
+
   selectedPokedex = signal<PokedexOption | null>(null);
   pokedex = signal<PokedexDetail | null>(null);
   loading = signal(true);
-  loadingDetail = signal(false);
   error = signal<string | null>(null);
+  searchTerm = signal('');
+
+  filteredEntries = computed(() => {
+    const entries = this.pokedex()?.pokemon_entries || [];
+    const term = this.searchTerm().toLowerCase().trim();
+
+    if (!term) return entries;
+
+    return entries.filter(entry =>
+      entry.pokemon_species.name.toLowerCase().includes(term)
+    );
+  });
+
+  viewedCount = computed(() => {
+    let count = 0;
+    this.filteredEntries().forEach(entry => {
+      const id = this.extractPokemonId(entry.pokemon_species.url);
+      if (this.progressService.isViewed(id)) count++;
+    });
+    return count;
+  });
 
   ngOnInit(): void {
     this.selectedPokedex.set(POKEDEX_OPTIONS[0]);
     this.loadPokedex(POKEDEX_OPTIONS[0].id);
+
+    this.searchControl.valueChanges.pipe(
+      debounceTime(200)
+    ).subscribe(value => {
+      this.searchTerm.set(value ?? '');
+    });
   }
 
   private loadPokedex(id: number): void {
@@ -107,9 +145,11 @@ export class RegionalPokedexComponent implements OnInit {
 
   selectPokedex(option: PokedexOption): void {
     this.selectedPokedex.set(option);
-    this.loadingDetail.set(true);
     this.loadPokedex(option.id);
-    setTimeout(() => this.loadingDetail.set(false), 0);
+  }
+
+  clearSearch(): void {
+    this.searchControl.setValue('');
   }
 
   extractPokemonId(url: string): number {
@@ -152,5 +192,9 @@ export class RegionalPokedexComponent implements OnInit {
 
   isInTeam(id: number): boolean {
     return this.teamService.isInTeam(id);
+  }
+
+  isViewed(id: number): boolean {
+    return this.progressService.isViewed(id);
   }
 }

--- a/src/app/services/data-service.service.ts
+++ b/src/app/services/data-service.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of, catchError, tap, retry } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of, catchError, tap, retry, forkJoin } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import {
   PokemonListResponse, PokemonDetail, PokemonSummary, PokemonSpecies, EvolutionChain,
   AbilityListResponse, AbilityDetail, MoveListResponse, MoveDetail,
-  PokedexListResponse, PokedexDetail, RegionDetail
+  PokedexListResponse, PokedexDetail, RegionDetail,
+  PokemonSpeciesDetail, LocationListResponse, LocationDetail, LocationAreaDetail,
+  TypeListResponse, TypeDetail, NatureListResponse, NatureDetail,
+  EggGroupListResponse, EggGroupDetail, GrowthRateDetail, CharacteristicDetail, EvolutionTriggerDetail
 } from '../shared/pokemon-api.interfaces';
 
 @Injectable({
@@ -19,17 +22,36 @@ export class DataServiceService {
   private readonly moveUrl = 'https://pokeapi.co/api/v2/move';
   private readonly pokedexUrl = 'https://pokeapi.co/api/v2/pokedex';
   private readonly regionUrl = 'https://pokeapi.co/api/v2/region';
+  private readonly locationUrl = 'https://pokeapi.co/api/v2/location';
+  private readonly locationAreaUrl = 'https://pokeapi.co/api/v2/location-area';
+  private readonly typeUrl = 'https://pokeapi.co/api/v2/type';
+  private readonly natureUrl = 'https://pokeapi.co/api/v2/nature';
+  private readonly eggGroupUrl = 'https://pokeapi.co/api/v2/egg-group';
+  private readonly growthRateUrl = 'https://pokeapi.co/api/v2/growth-rate';
+  private readonly characteristicUrl = 'https://pokeapi.co/api/v2/characteristic';
+  private readonly evolutionTriggerUrl = 'https://pokeapi.co/api/v2/evolution-trigger';
   private readonly maxPokemonCount = 1025;
   private allPokemonCache: PokemonSummary[] | null = null;
   private pokemonDetailCache = new Map<number, PokemonDetail>();
   private pokemonSpeciesCache = new Map<number, PokemonSpecies>();
+  private pokemonSpeciesDetailCache = new Map<number, PokemonSpeciesDetail>();
   private evolutionChainCache = new Map<number, EvolutionChain>();
   private abilityListCache: PokemonSummary[] | null = null;
   private moveListCache: PokemonSummary[] | null = null;
   private pokedexListCache: PokemonSummary[] | null = null;
+  private locationListCache: PokemonSummary[] | null = null;
+  private typeListCache: PokemonSummary[] | null = null;
+  private natureListCache: PokemonSummary[] | null = null;
+  private eggGroupListCache: PokemonSummary[] | null = null;
   private abilityDetailCache = new Map<number, AbilityDetail>();
   private moveDetailCache = new Map<number, MoveDetail>();
   private pokedexDetailCache = new Map<number, PokedexDetail>();
+  private locationDetailCache = new Map<number, LocationDetail>();
+  private locationAreaDetailCache = new Map<number, LocationAreaDetail>();
+  private typeDetailCache = new Map<number, TypeDetail>();
+  private natureDetailCache = new Map<number, NatureDetail>();
+  private eggGroupDetailCache = new Map<number, EggGroupDetail>();
+  private growthRateCache = new Map<number, GrowthRateDetail>();
 
   constructor(private http: HttpClient) {}
 
@@ -333,6 +355,332 @@ export class DataServiceService {
       catchError((error) => {
         console.error(`Error fetching region with id ${id}:`, error);
         return of({} as RegionDetail);
+      })
+    );
+  }
+
+  getPokemonSpeciesDetail(id: number): Observable<PokemonSpeciesDetail> {
+    if (id <= 0 || id > this.maxPokemonCount) {
+      return of({} as PokemonSpeciesDetail);
+    }
+    const cached = this.pokemonSpeciesDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<PokemonSpeciesDetail>(`${this.speciesUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.pokemonSpeciesDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching species detail for ID ${id}:`, error);
+        return of({} as PokemonSpeciesDetail);
+      })
+    );
+  }
+
+  getAllEvolutionChains(limit = 20, offset = 0): Observable<{ count: number; next: string | null; previous: string | null; results: { url: string }[] }> {
+    return this.http.get<{ count: number; next: string | null; previous: string | null; results: { url: string }[] }>(`${this.evolutionUrl}/?limit=${limit}&offset=${offset}`).pipe(
+      catchError((error) => {
+        console.error('Error fetching evolution chains:', error);
+        return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  getEvolutionChainById(id: number): Observable<EvolutionChain> {
+    if (id <= 0) {
+      return of({} as EvolutionChain);
+    }
+    const cached = this.evolutionChainCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<EvolutionChain>(`${this.evolutionUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.evolutionChainCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching evolution chain ${id}:`, error);
+        return of({} as EvolutionChain);
+      })
+    );
+  }
+
+  getLocationsList(limit = 20, offset = 0): Observable<LocationListResponse> {
+    return this.http.get<LocationListResponse>(`${this.locationUrl}/?limit=${limit}&offset=${offset}`).pipe(
+      catchError((error) => {
+        console.error('Error fetching locations list:', error);
+        return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  getAllLocations(): Observable<PokemonSummary[]> {
+    if (this.locationListCache) {
+      return of(this.locationListCache);
+    }
+    return this.http.get<LocationListResponse>(`${this.locationUrl}/?limit=1200`).pipe(
+      map((response) => {
+        this.locationListCache = response.results;
+        return this.locationListCache;
+      }),
+      catchError((error) => {
+        console.error('Error fetching all locations:', error);
+        return of([]);
+      })
+    );
+  }
+
+  getLocationDetail(id: number): Observable<LocationDetail> {
+    if (id <= 0) {
+      return of({} as LocationDetail);
+    }
+    const cached = this.locationDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<LocationDetail>(`${this.locationUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.locationDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching location ${id}:`, error);
+        return of({} as LocationDetail);
+      })
+    );
+  }
+
+  getLocationAreaDetail(id: number): Observable<LocationAreaDetail> {
+    if (id <= 0) {
+      return of({} as LocationAreaDetail);
+    }
+    const cached = this.locationAreaDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<LocationAreaDetail>(`${this.locationAreaUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.locationAreaDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching location area ${id}:`, error);
+        return of({} as LocationAreaDetail);
+      })
+    );
+  }
+
+  getTypesList(): Observable<TypeListResponse> {
+    return this.http.get<TypeListResponse>(`${this.typeUrl}/?limit=30`).pipe(
+      catchError((error) => {
+        console.error('Error fetching types list:', error);
+        return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  getAllTypes(): Observable<PokemonSummary[]> {
+    if (this.typeListCache) {
+      return of(this.typeListCache);
+    }
+    return this.getTypesList().pipe(
+      map((response) => {
+        this.typeListCache = response.results;
+        return this.typeListCache;
+      }),
+      catchError((error) => {
+        console.error('Error fetching all types:', error);
+        return of([]);
+      })
+    );
+  }
+
+  getTypeDetail(id: number): Observable<TypeDetail> {
+    if (id <= 0) {
+      return of({} as TypeDetail);
+    }
+    const cached = this.typeDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<TypeDetail>(`${this.typeUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.typeDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching type ${id}:`, error);
+        return of({} as TypeDetail);
+      })
+    );
+  }
+
+  getAllTypesWithDetails(): Observable<TypeDetail[]> {
+    return this.getAllTypes().pipe(
+      switchMap((types) => {
+        const requests = types.map(t => {
+          const id = parseInt(t.url.split('/').filter(Boolean).pop() ?? '0', 10);
+          return this.getTypeDetail(id);
+        });
+        return forkJoin(requests);
+      })
+    );
+  }
+
+  getNaturesList(limit = 20, offset = 0): Observable<NatureListResponse> {
+    return this.http.get<NatureListResponse>(`${this.natureUrl}/?limit=${limit}&offset=${offset}`).pipe(
+      catchError((error) => {
+        console.error('Error fetching natures list:', error);
+        return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  getAllNatures(): Observable<PokemonSummary[]> {
+    if (this.natureListCache) {
+      return of(this.natureListCache);
+    }
+    return this.http.get<NatureListResponse>(`${this.natureUrl}/?limit=30`).pipe(
+      map((response) => {
+        this.natureListCache = response.results;
+        return this.natureListCache;
+      }),
+      catchError((error) => {
+        console.error('Error fetching all natures:', error);
+        return of([]);
+      })
+    );
+  }
+
+  getNatureDetail(id: number): Observable<NatureDetail> {
+    if (id <= 0) {
+      return of({} as NatureDetail);
+    }
+    const cached = this.natureDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<NatureDetail>(`${this.natureUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.natureDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching nature ${id}:`, error);
+        return of({} as NatureDetail);
+      })
+    );
+  }
+
+  getEggGroupsList(): Observable<EggGroupListResponse> {
+    return this.http.get<EggGroupListResponse>(`${this.eggGroupUrl}/?limit=20`).pipe(
+      catchError((error) => {
+        console.error('Error fetching egg groups list:', error);
+        return of({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+  }
+
+  getAllEggGroups(): Observable<PokemonSummary[]> {
+    if (this.eggGroupListCache) {
+      return of(this.eggGroupListCache);
+    }
+    return this.getEggGroupsList().pipe(
+      map((response) => {
+        this.eggGroupListCache = response.results;
+        return this.eggGroupListCache;
+      }),
+      catchError((error) => {
+        console.error('Error fetching all egg groups:', error);
+        return of([]);
+      })
+    );
+  }
+
+  getEggGroupDetail(id: number): Observable<EggGroupDetail> {
+    if (id <= 0) {
+      return of({} as EggGroupDetail);
+    }
+    const cached = this.eggGroupDetailCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<EggGroupDetail>(`${this.eggGroupUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.eggGroupDetailCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching egg group ${id}:`, error);
+        return of({} as EggGroupDetail);
+      })
+    );
+  }
+
+  getGrowthRateDetail(id: number): Observable<GrowthRateDetail> {
+    if (id <= 0) {
+      return of({} as GrowthRateDetail);
+    }
+    const cached = this.growthRateCache.get(id);
+    if (cached) {
+      return of(cached);
+    }
+    return this.http.get<GrowthRateDetail>(`${this.growthRateUrl}/${id}/`).pipe(
+      retry(2),
+      tap((data) => {
+        if (data && data.id) {
+          this.growthRateCache.set(id, data);
+        }
+      }),
+      catchError((error) => {
+        console.error(`Error fetching growth rate ${id}:`, error);
+        return of({} as GrowthRateDetail);
+      })
+    );
+  }
+
+  getEvolutionTriggers(): Observable<EvolutionTriggerDetail[]> {
+    return this.http.get<{ results: PokemonSummary[] }>(`${this.evolutionTriggerUrl}/?limit=20`).pipe(
+      switchMap((response) => {
+        const requests = response.results.map(t => {
+          const id = parseInt(t.url.split('/').filter(Boolean).pop() ?? '0', 10);
+          return this.http.get<EvolutionTriggerDetail>(`${this.evolutionTriggerUrl}/${id}/`);
+        });
+        return forkJoin(requests);
+      }),
+      catchError((error) => {
+        console.error('Error fetching evolution triggers:', error);
+        return of([]);
+      })
+    );
+  }
+
+  getCharacteristicDetail(id: number): Observable<CharacteristicDetail> {
+    if (id <= 0) {
+      return of({} as CharacteristicDetail);
+    }
+    return this.http.get<CharacteristicDetail>(`${this.characteristicUrl}/${id}/`).pipe(
+      retry(2),
+      catchError((error) => {
+        console.error(`Error fetching characteristic ${id}:`, error);
+        return of({} as CharacteristicDetail);
       })
     );
   }

--- a/src/app/services/progress.service.ts
+++ b/src/app/services/progress.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, signal, computed, inject } from '@angular/core';
+import { StorageService } from './storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProgressService {
+  private storage = inject(StorageService);
+  private readonly STORAGE_KEY = 'viewed-pokemon';
+
+  private _viewedIds = signal<Set<number>>(new Set(this.storage.get<number[]>('viewed-pokemon') || []));
+
+  viewedCount = computed(() => this._viewedIds().size);
+  progressPercent = computed(() => Math.round((this._viewedIds().size / 1025) * 100));
+
+  isViewed(id: number): boolean {
+    return this._viewedIds().has(id);
+  }
+
+  markViewed(id: number): void {
+    if (id <= 0 || id > 1025) return;
+    const current = new Set(this._viewedIds());
+    current.add(id);
+    this._viewedIds.set(current);
+    this.storage.set(this.STORAGE_KEY, Array.from(current));
+  }
+
+  markUnviewed(id: number): void {
+    const current = new Set(this._viewedIds());
+    current.delete(id);
+    this._viewedIds.set(current);
+    this.storage.set(this.STORAGE_KEY, Array.from(current));
+  }
+
+  clearProgress(): void {
+    this._viewedIds.set(new Set());
+    this.storage.remove(this.STORAGE_KEY);
+  }
+}

--- a/src/app/shared/components/shortcuts-modal/shortcuts-modal.component.ts
+++ b/src/app/shared/components/shortcuts-modal/shortcuts-modal.component.ts
@@ -1,0 +1,243 @@
+import { Component, signal, HostListener } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+@Component({
+  selector: 'app-shortcuts-modal',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatButtonModule],
+  template: `
+    @if (isOpen()) {
+      <div class="modal-overlay" (click)="close()">
+        <div class="modal-content" (click)="$event.stopPropagation()">
+          <div class="modal-header">
+            <h2>
+              <mat-icon>keyboard</mat-icon>
+              Keyboard Shortcuts
+            </h2>
+            <button mat-icon-button (click)="close()" aria-label="Close">
+              <mat-icon>close</mat-icon>
+            </button>
+          </div>
+          <div class="modal-body">
+            @for (group of shortcutGroups(); track group.title) {
+              <div class="shortcut-group">
+                <h3>{{ group.title }}</h3>
+                @for (shortcut of group.shortcuts; track shortcut.description) {
+                  <div class="shortcut-row">
+                    <div class="shortcut-keys">
+                      @for (key of shortcut.keys; track key; let last = $last) {
+                        <kbd>{{ key }}</kbd>
+                        @if (!last) {
+                          <span class="key-separator">+</span>
+                        }
+                      }
+                    </div>
+                    <span class="shortcut-desc">{{ shortcut.description }}</span>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+          <div class="modal-footer">
+            <button mat-flat-button color="primary" (click)="close()">
+              Got it!
+            </button>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+  styles: [`
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(4px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      animation: fadeIn 200ms ease;
+    }
+
+    .modal-content {
+      background: var(--surface-card, #1a1a2e);
+      border: 1px solid var(--border, #333);
+      border-radius: 16px;
+      width: 90%;
+      max-width: 560px;
+      max-height: 80vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+      animation: slideUp 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .modal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 24px;
+      border-bottom: 1px solid var(--border, #333);
+
+      h2 {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--text-primary, #fff);
+
+        mat-icon {
+          color: var(--brand-primary, #8b5cf6);
+        }
+      }
+    }
+
+    .modal-body {
+      padding: 24px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .shortcut-group {
+      margin-bottom: 20px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      h3 {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-tertiary, #737373);
+        margin: 0 0 10px 0;
+      }
+    }
+
+    .shortcut-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 0;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      }
+    }
+
+    .shortcut-keys {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+
+      kbd {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 28px;
+        height: 28px;
+        padding: 0 8px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 6px;
+        font-family: 'Segoe UI', system-ui, sans-serif;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--text-primary, #fff);
+      }
+
+      .key-separator {
+        color: var(--text-tertiary, #737373);
+        font-size: 0.8rem;
+        margin: 0 2px;
+      }
+    }
+
+    .shortcut-desc {
+      font-size: 0.9rem;
+      color: var(--text-secondary, #aaa);
+    }
+
+    .modal-footer {
+      padding: 16px 24px;
+      border-top: 1px solid var(--border, #333);
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    @keyframes slideUp {
+      from { opacity: 0; transform: translateY(20px) scale(0.98); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `]
+})
+export class ShortcutsModalComponent {
+  isOpen = signal(false);
+
+  shortcutGroups = signal([
+    {
+      title: 'Navigation',
+      shortcuts: [
+        { keys: ['←', '→'], description: 'Navigate between Pokémon' },
+        { keys: ['Esc'], description: 'Close modals / blur inputs' },
+      ] as Shortcut[],
+    },
+    {
+      title: 'Actions',
+      shortcuts: [
+        { keys: ['S'], description: 'Toggle shiny sprite' },
+        { keys: ['F'], description: 'Toggle favorite' },
+        { keys: ['T'], description: 'Add to team' },
+      ] as Shortcut[],
+    },
+    {
+      title: 'Search',
+      shortcuts: [
+        { keys: ['Ctrl', 'K'], description: 'Focus search' },
+        { keys: ['/'], description: 'Quick search' },
+      ] as Shortcut[],
+    },
+    {
+      title: 'Help',
+      shortcuts: [
+        { keys: ['?'], description: 'Show this shortcuts panel' },
+      ] as Shortcut[],
+    },
+  ]);
+
+  open(): void {
+    this.isOpen.set(true);
+  }
+
+  close(): void {
+    this.isOpen.set(false);
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent): void {
+    if (event.key === '?' && !(event.target instanceof HTMLInputElement)) {
+      event.preventDefault();
+      this.open();
+    }
+    if (event.key === 'Escape' && this.isOpen()) {
+      this.close();
+    }
+  }
+}

--- a/src/app/shared/components/species-detail/species-detail.component.html
+++ b/src/app/shared/components/species-detail/species-detail.component.html
@@ -1,0 +1,148 @@
+<div class="species-detail-container" *ngIf="loading(); else loadedOrError">
+  <div class="spinner-wrapper">
+    <div class="spinner"></div>
+    <p>Loading species data...</p>
+  </div>
+</div>
+
+<ng-template #loadedOrError>
+  <div class="species-detail-container" *ngIf="error(); else loaded">
+    <div class="error-state">
+      <mat-icon>error_outline</mat-icon>
+      <p>{{ error() }}</p>
+    </div>
+  </div>
+
+  <ng-template #loaded>
+    <div class="species-detail-container" *ngIf="species()">
+      <section class="genus-header">
+        <h2 class="species-name">{{ capitalize(species()?.name || '') }}</h2>
+        <span class="genus-text">{{ getGenus() }}</span>
+        <div class="badges-row">
+          <span class="badge legendary" *ngIf="species()?.is_legendary">
+            <mat-icon>star</mat-icon> Legendary
+          </span>
+          <span class="badge mythical" *ngIf="species()?.is_mythical">
+            <mat-icon>auto_awesome</mat-icon> Mythical
+          </span>
+          <span class="badge baby" *ngIf="species()?.is_baby">
+            <mat-icon>child_care</mat-icon> Baby
+          </span>
+        </div>
+      </section>
+
+      <section class="flavor-text-section">
+        <blockquote class="flavor-text" *ngFor="let text of getFlavorTexts()">
+          "{{ text }}"
+        </blockquote>
+      </section>
+
+      <section class="stats-grid">
+        <div class="stat-card">
+          <span class="stat-label">Capture Rate</span>
+          <span class="stat-value">{{ species()?.capture_rate }}</span>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label">Base Happiness</span>
+          <span class="stat-value">{{ species()?.base_happiness }}</span>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label">Hatch Counter</span>
+          <span class="stat-value">{{ species()?.hatch_counter }} cycles</span>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label">Growth Rate</span>
+          <span class="stat-value">{{ capitalize(growthRateName()) }}</span>
+        </div>
+      </section>
+
+      <section class="egg-groups-section">
+        <h3 class="section-title">Egg Groups</h3>
+        <mat-chip-listbox class="egg-groups-chips">
+          <mat-chip-option *ngFor="let group of getEggGroupNames()" class="egg-group-chip">
+            {{ group }}
+          </mat-chip-option>
+        </mat-chip-listbox>
+      </section>
+
+      <section class="appearance-section">
+        <div class="appearance-item">
+          <span class="label">Color</span>
+          <span class="value">
+            <span class="color-dot" [style.background-color]="species()?.color?.name === 'unknown' ? '#888' : getColorHex(species()?.color?.name)"></span>
+            {{ capitalize(species()?.color?.name || '') }}
+          </span>
+        </div>
+        <div class="appearance-item">
+          <span class="label">Shape</span>
+          <span class="value">{{ capitalize(species()?.shape?.name || 'Unknown') }}</span>
+        </div>
+        <div class="appearance-item">
+          <span class="label">Habitat</span>
+          <span class="value">{{ species()?.habitat ? capitalize(species()?.habitat?.name ?? '') : 'Unknown' }}</span>
+        </div>
+      </section>
+
+      <section class="gender-ratio-section">
+        <h3 class="section-title">Gender Ratio</h3>
+        <div class="gender-bar-wrapper">
+          <ng-container *ngIf="getGenderRatio().genderless; else gendered">
+            <span class="genderless-text">Genderless</span>
+          </ng-container>
+          <ng-template #gendered>
+            <div class="gender-bar">
+              <div class="gender-male" [style.width.%]="getGenderRatio().male">
+                <span *ngIf="getGenderRatio().male > 10">♂ {{ getGenderRatio().male }}%</span>
+              </div>
+              <div class="gender-female" [style.width.%]="getGenderRatio().female">
+                <span *ngIf="getGenderRatio().female > 10">♀ {{ getGenderRatio().female }}%</span>
+              </div>
+            </div>
+          </ng-template>
+        </div>
+      </section>
+
+      <section class="pokedex-entries-section" *ngIf="getPokedexEntries().length > 0">
+        <h3 class="section-title">Pokédex Entries</h3>
+        <table class="pokedex-table">
+          <thead>
+            <tr>
+              <th>Pokédex</th>
+              <th>Entry #</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let entry of getPokedexEntries(); trackBy: trackByEntry">
+              <td>{{ capitalize(entry.pokedex.name) }}</td>
+              <td>{{ entry.entry_number }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="varieties-section" *ngIf="getVarieties().length > 1">
+        <h3 class="section-title">Forms</h3>
+        <div class="varieties-grid">
+          <a *ngFor="let v of getVarieties(); trackBy: trackByVariety"
+             [routerLink]="['/photo', getPokemonIdFromUrl(v.pokemon.url)]"
+             class="variety-link"
+             [class.is-default]="v.is_default">
+            <img [src]="'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/' + getPokemonIdFromUrl(v.pokemon.url) + '.png'"
+                 [alt]="v.pokemon.name"
+                 (error)="onImageError($event)" />
+            <span>{{ capitalize(v.pokemon.name) }}</span>
+            <span class="default-badge" *ngIf="v.is_default">Default</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="evolution-section" *ngIf="getEvolutionChainUrl()">
+        <h3 class="section-title">Evolution Chain</h3>
+        <app-evolution-chain
+          [pokemonId]="pokemonId"
+          [pokemonSpecies]="{ evolution_chain: { url: getEvolutionChainUrl()! } }">
+        </app-evolution-chain>
+      </section>
+    </div>
+  </ng-template>
+</ng-template>

--- a/src/app/shared/components/species-detail/species-detail.component.scss
+++ b/src/app/shared/components/species-detail/species-detail.component.scss
@@ -1,0 +1,413 @@
+:host {
+  --surface: rgba(255, 255, 255, 0.05);
+  --border: rgba(255, 255, 255, 0.1);
+  --text-primary: #ffffff;
+  --text-secondary: #a0a0a0;
+  --primary: #6366f1;
+  --surface-light: rgba(255, 255, 255, 0.08);
+}
+
+.species-detail-container {
+  padding: 1.5rem;
+  color: var(--text-primary);
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+.spinner-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 0;
+  gap: 1rem;
+
+  .spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--border);
+    border-top-color: var(--primary);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 0;
+  color: #ff6b6b;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+  }
+
+  p {
+    font-size: 1rem;
+  }
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.genus-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+
+  .species-name {
+    font-size: 2rem;
+    font-weight: 800;
+    text-transform: capitalize;
+    margin: 0 0 0.25rem;
+    background: linear-gradient(135deg, #fff 0%, #ccc 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .genus-text {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  .badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    flex-wrap: wrap;
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+
+      &.legendary {
+        background: rgba(255, 193, 7, 0.2);
+        color: #ffc107;
+        border: 1px solid rgba(255, 193, 7, 0.4);
+      }
+
+      &.mythical {
+        background: rgba(233, 30, 99, 0.2);
+        color: #e91e63;
+        border: 1px solid rgba(233, 30, 99, 0.4);
+      }
+
+      &.baby {
+        background: rgba(139, 195, 74, 0.2);
+        color: #8bc34a;
+        border: 1px solid rgba(139, 195, 74, 0.4);
+      }
+    }
+  }
+}
+
+.flavor-text-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  .flavor-text {
+    margin: 0;
+    padding: 1rem 1.25rem;
+    background: var(--surface);
+    border-left: 3px solid var(--primary);
+    border-radius: 0 8px 8px 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+
+    .stat-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: var(--text-secondary);
+    }
+
+    .stat-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+  }
+}
+
+.section-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
+}
+
+.egg-groups-section {
+  .egg-groups-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+
+    .egg-group-chip {
+      background: var(--surface-light);
+      border: 1px solid var(--border);
+      color: var(--text-primary);
+      font-size: 0.85rem;
+    }
+  }
+}
+
+.appearance-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+
+  .appearance-item {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    .label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: var(--text-secondary);
+    }
+
+    .value {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      text-transform: capitalize;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      .color-dot {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid var(--border);
+        flex-shrink: 0;
+      }
+    }
+  }
+}
+
+.gender-ratio-section {
+  .gender-bar-wrapper {
+    .genderless-text {
+      font-size: 1rem;
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    .gender-bar {
+      display: flex;
+      height: 32px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: var(--surface);
+      border: 1px solid var(--border);
+
+      .gender-male {
+        background: linear-gradient(135deg, #42a5f5, #1e88e5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #fff;
+        transition: width 0.3s ease;
+      }
+
+      .gender-female {
+        background: linear-gradient(135deg, #f06292, #e91e63);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #fff;
+        transition: width 0.3s ease;
+      }
+    }
+  }
+}
+
+.pokedex-entries-section {
+  .pokedex-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--surface);
+    border-radius: 12px;
+    overflow: hidden;
+
+    thead {
+      background: var(--surface-light);
+
+      th {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--text-secondary);
+        border-bottom: 1px solid var(--border);
+      }
+    }
+
+    tbody {
+      tr {
+        border-bottom: 1px solid var(--border);
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        td {
+          padding: 0.6rem 1rem;
+          font-size: 0.9rem;
+          color: var(--text-primary);
+          text-transform: capitalize;
+        }
+      }
+    }
+  }
+}
+
+.varieties-section {
+  .varieties-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 0.75rem;
+
+    .variety-link {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      text-decoration: none;
+      color: var(--text-primary);
+      transition: all 0.2s ease;
+      position: relative;
+
+      &:hover {
+        background: var(--surface-light);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      &.is-default {
+        border-color: var(--primary);
+        background: rgba(99, 102, 241, 0.1);
+      }
+
+      img {
+        width: 64px;
+        height: 64px;
+        object-fit: contain;
+        image-rendering: pixelated;
+      }
+
+      span {
+        font-size: 0.8rem;
+        text-transform: capitalize;
+        text-align: center;
+      }
+
+      .default-badge {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        font-size: 0.6rem;
+        padding: 0.15rem 0.4rem;
+        background: var(--primary);
+        color: #fff;
+        border-radius: 4px;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+    }
+  }
+}
+
+.evolution-section {
+  margin-top: 2rem;
+}
+
+@media (max-width: 600px) {
+  .species-detail-container {
+    padding: 1rem;
+  }
+
+  .genus-header {
+    .species-name {
+      font-size: 1.5rem;
+    }
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .appearance-section {
+    grid-template-columns: 1fr;
+  }
+
+  .varieties-grid {
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  }
+}

--- a/src/app/shared/components/species-detail/species-detail.component.ts
+++ b/src/app/shared/components/species-detail/species-detail.component.ts
@@ -1,0 +1,169 @@
+import { Component, Input, OnInit, inject, signal, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { DataServiceService } from '../../../services/data-service.service';
+import { PokemonSpeciesDetail, PokemonSummary } from '../../../shared/pokemon-api.interfaces';
+import { EvolutionChainComponent } from '../evolution-chain/evolution-chain.component';
+import { catchError, of } from 'rxjs';
+
+@Component({
+  selector: 'app-species-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, MatIconModule, MatButtonModule, MatChipsModule, EvolutionChainComponent],
+  templateUrl: './species-detail.component.html',
+  styleUrls: ['./species-detail.component.scss']
+})
+export class SpeciesDetailComponent implements OnInit, OnChanges {
+  private dataService = inject(DataServiceService);
+
+  @Input() pokemonId!: number;
+  @Input() speciesData: PokemonSpeciesDetail | null = null;
+
+  species = signal<PokemonSpeciesDetail | null>(null);
+  loading = signal(true);
+  error = signal<string | null>(null);
+  growthRateName = signal<string>('');
+
+  ngOnInit(): void {
+    this.loadSpeciesDetail();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['speciesData'] && this.speciesData) {
+      this.species.set(this.speciesData as unknown as PokemonSpeciesDetail);
+      this.loading.set(false);
+      if (this.speciesData.growth_rate) {
+        this.loadGrowthRateName(this.speciesData.growth_rate);
+      }
+    }
+  }
+
+  loadSpeciesDetail(): void {
+    if (this.speciesData) {
+      this.species.set(this.speciesData as unknown as PokemonSpeciesDetail);
+      this.loading.set(false);
+      if (this.speciesData.growth_rate) {
+        this.loadGrowthRateName(this.speciesData.growth_rate);
+      }
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.dataService.getPokemonSpeciesDetail(this.pokemonId).pipe(
+      catchError(() => {
+        this.error.set('Failed to load species data');
+        this.loading.set(false);
+        return of(null);
+      })
+    ).subscribe((data) => {
+      if (data && data.id) {
+        this.species.set(data);
+        this.loadGrowthRateName(data.growth_rate);
+        this.loading.set(false);
+      } else {
+        this.error.set('Species data not found');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  private loadGrowthRateName(growthRate: PokemonSummary): void {
+    const id = parseInt(growthRate.url.split('/').filter(Boolean).pop() ?? '0', 10);
+    this.dataService.getGrowthRateDetail(id).pipe(
+      catchError(() => of(null))
+    ).subscribe((detail) => {
+      if (detail) {
+        this.growthRateName.set(detail.name);
+      }
+    });
+  }
+
+  getGenus(): string {
+    const s = this.species();
+    if (!s) return '';
+    const englishGenus = s.genera.find(g => g.language.name === 'en');
+    return englishGenus?.genus || '';
+  }
+
+  getFlavorTexts(): string[] {
+    const s = this.species();
+    if (!s) return [];
+    const englishTexts = s.flavor_text_entries
+      .filter(f => f.language.name === 'en')
+      .map(f => f.flavor_text.replace(/[\n\f\r]/g, ' '));
+    const unique = [...new Set(englishTexts)];
+    return unique.slice(-3);
+  }
+
+  getGenderRatio(): { male: number; female: number; genderless: boolean } {
+    const s = this.species();
+    if (!s) return { male: 50, female: 50, genderless: false };
+    if (s.gender_rate === -1) return { male: 0, female: 0, genderless: true };
+    if (s.gender_rate === 0) return { male: 100, female: 0, genderless: false };
+    if (s.gender_rate === 8) return { male: 0, female: 100, genderless: false };
+    const femalePercent = (s.gender_rate / 8) * 100;
+    return { male: Math.round(100 - femalePercent), female: Math.round(femalePercent), genderless: false };
+  }
+
+  getEggGroupNames(): string[] {
+    const s = this.species();
+    if (!s) return [];
+    return s.egg_groups.map(eg => this.capitalize(eg.name));
+  }
+
+  getPokedexEntries() {
+    const s = this.species();
+    if (!s) return [];
+    return s.pokedex_numbers.slice(0, 12);
+  }
+
+  getVarieties() {
+    const s = this.species();
+    if (!s) return [];
+    return s.varieties;
+  }
+
+  getEvolutionChainUrl(): string | null {
+    const s = this.species();
+    return s?.evolution_chain?.url || null;
+  }
+
+  capitalize(str: string): string {
+    if (!str) return '';
+    return str.charAt(0).toUpperCase() + str.slice(1).replace(/-/g, ' ');
+  }
+
+  getPokemonIdFromUrl(url: string): number {
+    const parts = url.split('/').filter(Boolean);
+    return parseInt(parts[parts.length - 1], 10);
+  }
+
+  trackByEntry(index: number, entry: { entry_number: number; pokedex: PokemonSummary }): string {
+    return `${entry.pokedex.name}-${entry.entry_number}`;
+  }
+
+  trackByVariety(index: number, variety: { is_default: boolean; pokemon: PokemonSummary }): string {
+    return variety.pokemon.name;
+  }
+
+  getColorHex(colorName: string | undefined): string {
+    const colors: Record<string, string> = {
+      black: '#343434', blue: '#5090d6', brown: '#b07840', gray: '#888888',
+      green: '#78c850', pink: '#f898d8', purple: '#a040a0', red: '#f08030',
+      white: '#f8f8f8', yellow: '#f8d030'
+    };
+    return colors[colorName || ''] || '#888888';
+  }
+
+  onImageError(event: Event): void {
+    const target = event.target as HTMLImageElement;
+    if (target) {
+      target.src = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/0.png';
+    }
+  }
+}

--- a/src/app/shared/components/sprite-gallery/sprite-gallery.component.ts
+++ b/src/app/shared/components/sprite-gallery/sprite-gallery.component.ts
@@ -1,0 +1,209 @@
+import { Component, Input, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+interface SpriteVariant {
+  name: string;
+  url: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-sprite-gallery',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatTooltipModule],
+  template: `
+    @if (sprites().length > 0) {
+      <div class="sprite-gallery">
+        <div class="gallery-header">
+          <h3 class="gallery-title">
+            <mat-icon>image</mat-icon>
+            Sprite Gallery
+          </h3>
+          <span class="gallery-count">{{ sprites().length }} variants</span>
+        </div>
+        <div class="gallery-grid">
+          @for (sprite of sprites(); track sprite.name) {
+            <div class="sprite-item" [matTooltip]="sprite.label">
+              <div class="sprite-frame">
+                <img
+                  [src]="sprite.url"
+                  [alt]="sprite.label"
+                  loading="lazy"
+                  (error)="onImageError($event)"
+                />
+              </div>
+              <span class="sprite-label">{{ sprite.label }}</span>
+            </div>
+          }
+        </div>
+      </div>
+    }
+  `,
+  styles: [`
+    .sprite-gallery {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 1.25rem 1.5rem;
+      margin-top: 1rem;
+    }
+
+    .gallery-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+
+      .gallery-title {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--text-primary, #fff);
+        margin: 0;
+
+        mat-icon {
+          color: var(--brand-primary, #8b5cf6);
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+        }
+      }
+
+      .gallery-count {
+        font-size: 0.75rem;
+        color: var(--text-tertiary, #737373);
+        background: rgba(255, 255, 255, 0.06);
+        padding: 2px 10px;
+        border-radius: 10px;
+      }
+    }
+
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+      gap: 12px;
+    }
+
+    .sprite-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      transition: transform 200ms ease;
+
+      &:hover {
+        transform: scale(1.08);
+
+        .sprite-frame {
+          border-color: var(--brand-primary, #8b5cf6);
+          box-shadow: 0 4px 12px rgba(139, 92, 246, 0.2);
+        }
+      }
+    }
+
+    .sprite-frame {
+      width: 80px;
+      height: 80px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      overflow: hidden;
+      transition: all 200ms ease;
+
+      img {
+        width: 64px;
+        height: 64px;
+        object-fit: contain;
+        image-rendering: pixelated;
+      }
+    }
+
+    .sprite-label {
+      font-size: 0.65rem;
+      color: var(--text-tertiary, #737373);
+      text-align: center;
+      line-height: 1.3;
+      max-width: 90px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    @media (max-width: 768px) {
+      .gallery-grid {
+        grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+        gap: 8px;
+      }
+
+      .sprite-frame {
+        width: 64px;
+        height: 64px;
+
+        img {
+          width: 52px;
+          height: 52px;
+        }
+      }
+    }
+  `]
+})
+export class SpriteGalleryComponent {
+  @Input() pokemonId = 0;
+  @Input() isShiny = false;
+
+  sprites = signal<SpriteVariant[]>([]);
+
+  ngOnChanges(): void {
+    this.loadSprites();
+  }
+
+  private loadSprites(): void {
+    if (!this.pokemonId) return;
+
+    const id = this.pokemonId;
+    const prefix = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon';
+    const variants: SpriteVariant[] = [];
+
+    const normalSprites = [
+      { url: `${prefix}/${id}.png`, label: 'Front' },
+      { url: `${prefix}/back/${id}.png`, label: 'Back' },
+      { url: `${prefix}/other/official-artwork/${id}.png`, label: 'Official Artwork' },
+      { url: `${prefix}/other/dream-world/${id}.svg`, label: 'Dream World' },
+      { url: `${prefix}/other/home/${id}.png`, label: 'Home' },
+    ];
+
+    const shinyPrefix = this.isShiny ? '/shiny' : '';
+    const shinySprites = [
+      { url: `${prefix}${shinyPrefix}/${id}.png`, label: this.isShiny ? 'Shiny Front' : 'Normal Front' },
+      { url: `${prefix}${shinyPrefix}/back/${id}.png`, label: this.isShiny ? 'Shiny Back' : 'Normal Back' },
+      { url: `${prefix}/other/official-artwork${shinyPrefix}/${id}.png`, label: this.isShiny ? 'Shiny Artwork' : 'Normal Artwork' },
+    ];
+
+    const allSprites = [...normalSprites, ...shinySprites];
+
+    allSprites.forEach(s => {
+      variants.push({
+        name: s.label.toLowerCase().replace(/\s+/g, '-'),
+        url: s.url,
+        label: s.label,
+      });
+    });
+
+    this.sprites.set(variants);
+  }
+
+  onImageError(event: Event): void {
+    const target = event.target as HTMLImageElement;
+    if (target) {
+      target.style.display = 'none';
+    }
+  }
+}

--- a/src/app/shared/components/stats-radar/stats-radar.component.ts
+++ b/src/app/shared/components/stats-radar/stats-radar.component.ts
@@ -1,0 +1,228 @@
+import { Component, Input, computed, ElementRef, ViewChild, AfterViewInit, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+interface StatPoint {
+  label: string;
+  value: number;
+  maxValue: number;
+}
+
+@Component({
+  selector: 'app-stats-radar',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  template: `
+    <div class="radar-container">
+      <div class="radar-header">
+        <h3 class="radar-title">
+          <mat-icon>radar</mat-icon>
+          Stat Distribution
+        </h3>
+        <span class="radar-total">Total: {{ totalStats() }}</span>
+      </div>
+      <div class="radar-canvas-wrapper">
+        <canvas #radarCanvas [width]="size" [height]="size"></canvas>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .radar-container {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 1.25rem 1.5rem;
+      margin-top: 1rem;
+    }
+
+    .radar-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+
+      .radar-title {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--text-primary, #fff);
+        margin: 0;
+
+        mat-icon {
+          color: var(--brand-primary, #8b5cf6);
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+        }
+      }
+
+      .radar-total {
+        font-size: 0.8rem;
+        font-weight: 700;
+        color: var(--brand-primary, #8b5cf6);
+        background: rgba(139, 92, 246, 0.1);
+        padding: 4px 12px;
+        border-radius: 10px;
+      }
+    }
+
+    .radar-canvas-wrapper {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    canvas {
+      max-width: 100%;
+      height: auto;
+    }
+  `]
+})
+export class StatsRadarComponent implements AfterViewInit, OnChanges {
+  @Input() stats: { name: string; value: number }[] = [];
+  @Input() size = 280;
+
+  @ViewChild('radarCanvas') canvasRef!: ElementRef<HTMLCanvasElement>;
+
+  private shortNames: Record<string, string> = {
+    'hp': 'HP',
+    'attack': 'ATK',
+    'defense': 'DEF',
+    'special-attack': 'SPA',
+    'special-defense': 'SPD',
+    'speed': 'SPE'
+  };
+
+  statPoints = computed<StatPoint[]>(() =>
+    this.stats.map(s => ({
+      label: this.shortNames[s.name] || s.name,
+      value: s.value,
+      maxValue: 255
+    }))
+  );
+
+  totalStats = computed(() => this.stats.reduce((sum, s) => sum + s.value, 0));
+
+  ngAfterViewInit(): void {
+    this.drawRadar();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['stats'] && this.canvasRef) {
+      this.drawRadar();
+    }
+  }
+
+  private drawRadar(): void {
+    const canvas = this.canvasRef?.nativeElement;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const points = this.statPoints();
+    if (points.length === 0) return;
+
+    const width = this.size;
+    const height = this.size;
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const radius = Math.min(width, height) / 2 - 40;
+    const levels = 5;
+
+    ctx.clearRect(0, 0, width, height);
+
+    const angleStep = (Math.PI * 2) / points.length;
+
+    for (let level = 1; level <= levels; level++) {
+      const levelRadius = (radius / levels) * level;
+      ctx.beginPath();
+      for (let i = 0; i <= points.length; i++) {
+        const angle = angleStep * i - Math.PI / 2;
+        const x = centerX + levelRadius * Math.cos(angle);
+        const y = centerY + levelRadius * Math.sin(angle);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    for (let i = 0; i < points.length; i++) {
+      const angle = angleStep * i - Math.PI / 2;
+      const x = centerX + radius * Math.cos(angle);
+      const y = centerY + radius * Math.sin(angle);
+
+      ctx.beginPath();
+      ctx.moveTo(centerX, centerY);
+      ctx.lineTo(x, y);
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    ctx.beginPath();
+    for (let i = 0; i <= points.length; i++) {
+      const idx = i % points.length;
+      const angle = angleStep * idx - Math.PI / 2;
+      const valueRatio = Math.min(points[idx].value / points[idx].maxValue, 1);
+      const pointRadius = radius * valueRatio;
+      const x = centerX + pointRadius * Math.cos(angle);
+      const y = centerY + pointRadius * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+
+    const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, radius);
+    gradient.addColorStop(0, 'rgba(139, 92, 246, 0.3)');
+    gradient.addColorStop(1, 'rgba(99, 102, 241, 0.1)');
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(139, 92, 246, 0.8)';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    for (let i = 0; i < points.length; i++) {
+      const angle = angleStep * i - Math.PI / 2;
+      const valueRatio = Math.min(points[i].value / points[i].maxValue, 1);
+      const pointRadius = radius * valueRatio;
+      const x = centerX + pointRadius * Math.cos(angle);
+      const y = centerY + pointRadius * Math.sin(angle);
+
+      ctx.beginPath();
+      ctx.arc(x, y, 4, 0, Math.PI * 2);
+      ctx.fillStyle = '#8b5cf6';
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+
+    ctx.font = '600 11px Segoe UI, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    for (let i = 0; i < points.length; i++) {
+      const angle = angleStep * i - Math.PI / 2;
+      const labelRadius = radius + 24;
+      const x = centerX + labelRadius * Math.cos(angle);
+      const y = centerY + labelRadius * Math.sin(angle);
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
+      ctx.fillText(points[i].label, x, y);
+
+      const valueX = centerX + (radius * 0.5) * Math.cos(angle);
+      const valueY = centerY + (radius * 0.5) * Math.sin(angle);
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.4)';
+      ctx.font = '500 10px Segoe UI, system-ui, sans-serif';
+      ctx.fillText(points[i].value.toString(), valueX, valueY);
+      ctx.font = '600 11px Segoe UI, system-ui, sans-serif';
+    }
+  }
+}

--- a/src/app/shared/pokemon-api.interfaces.ts
+++ b/src/app/shared/pokemon-api.interfaces.ts
@@ -257,3 +257,247 @@ export interface RegionDetail {
   version_groups: PokemonSummary[];
 }
 
+export interface PokemonSpeciesDetail {
+  id: number;
+  name: string;
+  order: number;
+  gender_rate: number;
+  capture_rate: number;
+  base_happiness: number;
+  is_baby: boolean;
+  is_legendary: boolean;
+  is_mythical: boolean;
+  hatch_counter: number;
+  has_gender_differences: boolean;
+  forms_switchable: boolean;
+  growth_rate: PokemonSummary;
+  pokedex_numbers: PokedexNumberEntry[];
+  egg_groups: PokemonSummary[];
+  color: PokemonSummary;
+  shape: PokemonSummary;
+  evolves_from_species: PokemonSummary | null;
+  evolution_chain: { url: string };
+  habitat: PokemonSummary | null;
+  generation: PokemonSummary;
+  names: NameEntry[];
+  pal_park_encounters: PalParkEncounter[];
+  flavor_text_entries: FlavorTextEntry[];
+  form_descriptions: DescriptionEntry[];
+  genera: GenusEntry[];
+  varieties: PokemonSpeciesVariety[];
+}
+
+export interface PokedexNumberEntry {
+  entry_number: number;
+  pokedex: PokemonSummary;
+}
+
+export interface PalParkEncounter {
+  area: PokemonSummary;
+  base_score: number;
+  rate: number;
+}
+
+export interface FlavorTextEntry {
+  flavor_text: string;
+  language: PokemonSummary;
+  version: PokemonSummary;
+}
+
+export interface GenusEntry {
+  genus: string;
+  language: PokemonSummary;
+}
+
+export interface PokemonSpeciesVariety {
+  is_default: boolean;
+  pokemon: PokemonSummary;
+}
+
+export interface LocationListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonSummary[];
+}
+
+export interface LocationDetail {
+  id: number;
+  name: string;
+  region: PokemonSummary | null;
+  names: NameEntry[];
+  game_indices: LocationGameIndex[];
+  areas: PokemonSummary[];
+}
+
+export interface LocationGameIndex {
+  game_index: number;
+  generation: PokemonSummary;
+}
+
+export interface LocationAreaDetail {
+  id: number;
+  name: string;
+  game_index: number;
+  encounter_method_rates: EncounterMethodRate[];
+  location: PokemonSummary;
+  names: LocationAreaName[];
+  pokemon_encounters: PokemonEncounter[];
+}
+
+export interface EncounterMethodRate {
+  encounter_method: PokemonSummary;
+  version_details: EncounterVersionDetail[];
+}
+
+export interface EncounterVersionDetail {
+  rate: number;
+  version: PokemonSummary;
+}
+
+export interface LocationAreaName {
+  name: string;
+  language: PokemonSummary;
+}
+
+export interface PokemonEncounter {
+  pokemon: PokemonSummary;
+  version_details: EncounterVersionDetailWithMethods[];
+}
+
+export interface EncounterVersionDetailWithMethods {
+  version: PokemonSummary;
+  max_chance: number;
+  encounter_details: EncounterDetail[];
+}
+
+export interface EncounterDetail {
+  min_level: number;
+  max_level: number;
+  condition_values: PokemonSummary[];
+  chance: number;
+  method: PokemonSummary;
+}
+
+export interface TypeListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonSummary[];
+}
+
+export interface TypeDetail {
+  id: number;
+  name: string;
+  damage_relations: TypeDamageRelations;
+  past_damage_relations: TypePastDamageRelation[];
+  game_indices: TypeGameIndex[];
+  generation: PokemonSummary;
+  move_damage_class: PokemonSummary | null;
+  names: NameEntry[];
+  pokemon: TypePokemonEntry[];
+  moves: PokemonSummary[];
+}
+
+export interface TypeDamageRelations {
+  no_damage_to: PokemonSummary[];
+  half_damage_to: PokemonSummary[];
+  double_damage_to: PokemonSummary[];
+  no_damage_from: PokemonSummary[];
+  half_damage_from: PokemonSummary[];
+  double_damage_from: PokemonSummary[];
+}
+
+export interface TypePastDamageRelation {
+  generation: PokemonSummary;
+  damage_relations: TypeDamageRelations;
+}
+
+export interface TypeGameIndex {
+  game_index: number;
+  generation: PokemonSummary;
+}
+
+export interface TypePokemonEntry {
+  slot: number;
+  pokemon: PokemonSummary;
+}
+
+export interface NatureListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonSummary[];
+}
+
+export interface NatureDetail {
+  id: number;
+  name: string;
+  decreased_stat: PokemonSummary | null;
+  increased_stat: PokemonSummary | null;
+  hates_flavor: PokemonSummary | null;
+  likes_flavor: PokemonSummary | null;
+  pokeathlon_stat_changes: PokeathlonStatChange[];
+  move_battle_style_preferences: MoveBattleStylePreference[];
+  names: NameEntry[];
+}
+
+export interface PokeathlonStatChange {
+  max_change: number;
+  pokeathlon_stat: PokemonSummary;
+}
+
+export interface MoveBattleStylePreference {
+  low_hp_preference: number;
+  high_hp_preference: number;
+  move_battle_style: PokemonSummary;
+}
+
+export interface EggGroupListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonSummary[];
+}
+
+export interface EggGroupDetail {
+  id: number;
+  name: string;
+  names: NameEntry[];
+  pokemon_species: PokemonSummary[];
+}
+
+export interface GrowthRateDetail {
+  id: number;
+  name: string;
+  formula: string;
+  descriptions: DescriptionEntry[];
+  levels: GrowthRateLevel[];
+  pokemon_species: PokemonSummary[];
+}
+
+export interface GrowthRateLevel {
+  level: number;
+  experience: number;
+}
+
+export interface CharacteristicDetail {
+  id: number;
+  gene_modulo: number;
+  possible_values: number[];
+  highest_stat: PokemonSummary;
+  descriptions: CharacteristicDescription[];
+}
+
+export interface CharacteristicDescription {
+  description: string;
+  language: PokemonSummary;
+}
+
+export interface EvolutionTriggerDetail {
+  id: number;
+  name: string;
+  names: NameEntry[];
+  pokemon_species: PokemonSummary[];
+}
+

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -47,8 +47,13 @@ export class SidebarComponent implements OnInit {
   navItems = computed<NavItem[]>(() => [
     { path: '/', icon: 'home', label: 'Home' },
     { path: '/catalog', icon: 'book', label: 'Pokédex' },
+    { path: '/evolution-chains', icon: 'account_tree', label: 'Evolutions' },
     { path: '/moves', icon: 'menu_book', label: 'Moves' },
     { path: '/abilities', icon: 'psychology', label: 'Abilities' },
+    { path: '/battle-strategy', icon: 'bolt', label: 'Battle' },
+    { path: '/types', icon: 'category', label: 'Types' },
+    { path: '/locations', icon: 'map', label: 'Locations' },
+    { path: '/natures', icon: 'psychology_alt', label: 'Natures' },
     { path: '/compare', icon: 'compare_arrows', label: 'Compare' },
     { path: '/favorites', icon: 'favorite', label: 'Favorites', badge: this.favoritesCount() },
     { path: '/team', icon: 'groups', label: 'My Team', badge: this.teamCount() }

--- a/src/app/types-deep-dive/types-deep-dive.component.html
+++ b/src/app/types-deep-dive/types-deep-dive.component.html
@@ -1,0 +1,149 @@
+<div class="types-deep-dive">
+  <ds-page-header title="Types" subtitle="Explore all 18 Pokémon types and their relationships"></ds-page-header>
+
+  @if (loading()) {
+    <div class="loading-container">
+      <ds-pokeball-spinner [size]="80" label="Loading types..."></ds-pokeball-spinner>
+    </div>
+  } @else if (!selectedType()) {
+    <div class="types-grid">
+      @for (type of allTypes(); track type.id) {
+        <div
+          class="type-card"
+          [style.--type-color]="getTypeColor(type.name)"
+          (click)="selectType(type)"
+          (keydown.enter)="selectType(type)"
+          tabindex="0"
+          role="button"
+          [attr.aria-label]="capitalize(type.name) + ' type'"
+        >
+          <div class="type-card-icon">
+            <ds-type-badge [type]="type.name" size="lg" variant="solid"></ds-type-badge>
+          </div>
+          <div class="type-card-count">
+            {{ type.pokemon.length }} Pokémon
+          </div>
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="type-detail">
+      <div class="type-detail-header">
+        <button mat-icon-button (click)="goBack()" aria-label="Back to types">
+          <mat-icon>arrow_back</mat-icon>
+        </button>
+        <ds-type-badge [type]="selectedType()!.name" size="lg" variant="solid"></ds-type-badge>
+        <span class="type-detail-title">{{ capitalize(selectedType()!.name) }}</span>
+      </div>
+
+      <mat-tab-group [(selectedIndex)]="selectedTab" class="type-tabs">
+        <mat-tab label="Effectiveness">
+          <div class="effectiveness-tab">
+            @if (typeEffectiveness(); as eff) {
+              <div class="effectiveness-grid">
+                <div class="effectiveness-section">
+                  <h3>Weak To</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.doubleDamageFrom; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.doubleDamageFrom.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+
+                <div class="effectiveness-section">
+                  <h3>Resistant To</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.halfDamageFrom; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.halfDamageFrom.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+
+                <div class="effectiveness-section">
+                  <h3>Immune To</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.noDamageFrom; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.noDamageFrom.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+
+                <div class="effectiveness-section">
+                  <h3>Strong Against</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.doubleDamageTo; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.doubleDamageTo.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+
+                <div class="effectiveness-section">
+                  <h3>Not Very Effective Against</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.halfDamageTo; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.halfDamageTo.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+
+                <div class="effectiveness-section">
+                  <h3>No Effect Against</h3>
+                  <div class="type-list">
+                    @for (typeName of eff.noDamageTo; track typeName) {
+                      <ds-type-badge [type]="typeName" size="sm" variant="outline"></ds-type-badge>
+                    }
+                    @if (eff.noDamageTo.length === 0) {
+                      <span class="none-text">None</span>
+                    }
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        </mat-tab>
+
+        <mat-tab label="Pokémon">
+          <div class="pokemon-tab">
+            <div class="pokemon-grid">
+              @for (pokemon of typePokemon(); track pokemon.id) {
+                <ds-poke-card
+                  [pokemon]="pokemon"
+                  [showTypes]="true"
+                  (cardClick)="navigateToPokemon(pokemon.id)"
+                ></ds-poke-card>
+              }
+            </div>
+          </div>
+        </mat-tab>
+
+        <mat-tab label="Moves">
+          <div class="moves-tab">
+            <div class="moves-list">
+              @for (move of typeMoves(); track move.name) {
+                <div class="move-item" (click)="navigateToMove(move)">
+                  <span class="move-name">{{ capitalize(move.name) }}</span>
+                  <mat-icon>chevron_right</mat-icon>
+                </div>
+              }
+            </div>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
+  }
+</div>

--- a/src/app/types-deep-dive/types-deep-dive.component.scss
+++ b/src/app/types-deep-dive/types-deep-dive.component.scss
@@ -1,0 +1,174 @@
+:host {
+  display: block;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.types-deep-dive {
+  padding-bottom: 60px;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  padding: 80px 0;
+}
+
+.types-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.type-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 200ms ease;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: var(--type-color, #a8a878);
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-card-hover);
+    border-color: var(--type-color, #a8a878);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #8b5cf6;
+    outline-offset: 2px;
+  }
+}
+
+.type-card-icon {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+}
+
+.type-card-count {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.type-detail {
+  background: var(--surface-card);
+  border: 1px solid var(--border-default);
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.type-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.type-detail-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.type-tabs {
+  ::ng-deep .mat-mdc-tab-header {
+    border-bottom: 1px solid var(--border-default);
+  }
+}
+
+.effectiveness-tab {
+  padding: 24px 0;
+}
+
+.effectiveness-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.effectiveness-section {
+  h3 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 12px 0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
+.type-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.none-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.pokemon-tab {
+  padding: 24px 0;
+}
+
+.pokemon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.moves-tab {
+  padding: 24px 0;
+}
+
+.moves-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.move-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: var(--surface-card-hover);
+    border-color: #8b5cf6;
+    box-shadow: var(--shadow-card);
+  }
+}
+
+.move-name {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-transform: capitalize;
+}

--- a/src/app/types-deep-dive/types-deep-dive.component.ts
+++ b/src/app/types-deep-dive/types-deep-dive.component.ts
@@ -1,0 +1,129 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { DataServiceService } from '../services/data-service.service';
+import { TypeDetail, PokemonSummary } from '../shared/pokemon-api.interfaces';
+import { TypeBadgeComponent } from '../shared/components/type-badge/type-badge.component';
+import { PokeCardComponent, PokeCardPokemon } from '../shared/components/poke-card/poke-card.component';
+import { PokeballSpinnerComponent } from '../shared/components/pokeball-spinner/pokeball-spinner.component';
+import { PageHeaderComponent } from '../shared/components/page-header/page-header.component';
+import { getTypeColor } from '../shared/utils/type.utils';
+import { capitalize } from '../shared/utils/pokemon.utils';
+import { catchError, of } from 'rxjs';
+
+interface TypeEffectiveness {
+  doubleDamageFrom: string[];
+  halfDamageFrom: string[];
+  noDamageFrom: string[];
+  doubleDamageTo: string[];
+  halfDamageTo: string[];
+  noDamageTo: string[];
+}
+
+@Component({
+  selector: 'app-types-deep-dive',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    TypeBadgeComponent,
+    PokeCardComponent,
+    PokeballSpinnerComponent,
+    PageHeaderComponent
+  ],
+  templateUrl: './types-deep-dive.component.html',
+  styleUrl: './types-deep-dive.component.scss'
+})
+export class TypesDeepDiveComponent implements OnInit {
+  private dataService = inject(DataServiceService);
+  private router = inject(Router);
+
+  allTypes = signal<TypeDetail[]>([]);
+  selectedType = signal<TypeDetail | null>(null);
+  loading = signal(true);
+  selectedTab = signal(0);
+
+  typeEffectiveness = computed<TypeEffectiveness | null>(() => {
+    const type = this.selectedType();
+    if (!type) return null;
+    const dr = type.damage_relations;
+    return {
+      doubleDamageFrom: dr.double_damage_from.map(t => t.name),
+      halfDamageFrom: dr.half_damage_from.map(t => t.name),
+      noDamageFrom: dr.no_damage_from.map(t => t.name),
+      doubleDamageTo: dr.double_damage_to.map(t => t.name),
+      halfDamageTo: dr.half_damage_to.map(t => t.name),
+      noDamageTo: dr.no_damage_to.map(t => t.name)
+    };
+  });
+
+  typePokemon = computed<PokeCardPokemon[]>(() => {
+    const type = this.selectedType();
+    if (!type) return [];
+    return type.pokemon.slice(0, 20).map(entry => {
+      const id = parseInt(entry.pokemon.url.split('/').filter(Boolean).pop() ?? '0', 10);
+      return {
+        id,
+        name: entry.pokemon.name,
+        spriteUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`,
+        types: [{ type: { name: type.name } }]
+      };
+    });
+  });
+
+  typeMoves = computed<PokemonSummary[]>(() => {
+    const type = this.selectedType();
+    if (!type) return [];
+    return type.moves.slice(0, 20);
+  });
+
+  ngOnInit(): void {
+    this.loadTypes();
+  }
+
+  loadTypes(): void {
+    this.loading.set(true);
+    this.dataService.getAllTypesWithDetails().pipe(
+      catchError(() => of([]))
+    ).subscribe(types => {
+      this.allTypes.set(types.filter(t => t.id <= 18));
+      this.loading.set(false);
+    });
+  }
+
+  selectType(type: TypeDetail): void {
+    this.selectedType.set(type);
+    this.selectedTab.set(0);
+  }
+
+  goBack(): void {
+    this.selectedType.set(null);
+  }
+
+  navigateToMove(move: PokemonSummary): void {
+    const id = parseInt(move.url.split('/').filter(Boolean).pop() ?? '0', 10);
+    this.router.navigate(['/move', id]);
+  }
+
+  navigateToPokemon(id: number): void {
+    this.router.navigate(['/photo', id]);
+  }
+
+  getTypeColor(typeName: string): string {
+    return getTypeColor(typeName);
+  }
+
+  capitalize(value: string): string {
+    return capitalize(value);
+  }
+
+  trackByName(_index: number, item: { name: string }): string {
+    return item.name;
+  }
+}


### PR DESCRIPTION
…ariables

- Add Types Deep Dive, Locations, Natures & Stats, Battle Strategy, and Evolution Chains pages
- Add shared components: SpeciesDetail, SpriteGallery, StatsRadar, ShortcutsModal
- Add ProgressService for loading state management
- Extend DataService with new API endpoints for types, locations, natures, characteristics, and evolution chains
- Fix CSS variable references across Types, Locations, and Natures components to use design system tokens (--surface-card, --border-default, --text-primary, etc.) instead of hardcoded light-theme fallbacks
- Update routing with new lazy-loaded routes
- Enhance home page with new feature cards